### PR TITLE
#60 Decouple SignManager and BlueMapAPIConnector through listener

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loader_version=0.15.11
 # Mod Properties
 mod_id=bluemapsignmarkers
 mod_name=BlueMap Sign Markers
-mod_version=1.21.1-0.3.4
+mod_version=1.21.1-0.3.5
 mod_description=A plugin for BlueMap that creates markers from signs
 maven_group=com.tpwalke2.bluemapsignmarkers
 archives_base_name=bluemapsignmarkers

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
@@ -8,7 +8,6 @@ import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.UpdateMarkerAction;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupType;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerSetIdentifier;
 import com.tpwalke2.bluemapsignmarkers.core.reactive.ReactiveQueue;
-import com.tpwalke2.bluemapsignmarkers.core.signs.SignManager;
 import de.bluecolored.bluemap.api.BlueMapAPI;
 import de.bluecolored.bluemap.api.BlueMapMap;
 import de.bluecolored.bluemap.api.markers.MarkerSet;
@@ -16,6 +15,8 @@ import de.bluecolored.bluemap.api.markers.POIMarker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,6 +29,7 @@ public class BlueMapAPIConnector {
     private ReactiveQueue<MarkerAction> markerActionQueue;
     private Map<MarkerSetIdentifier, MarkerSet> markerSets;
     private BlueMapAPI blueMapAPI;
+    private List<IResetHandler> resetHandlers = new ArrayList<>();
 
     public BlueMapAPIConnector() {
         resetQueue();
@@ -43,6 +45,14 @@ public class BlueMapAPIConnector {
 
     public void dispatch(MarkerAction action) {
         markerActionQueue.enqueue(action);
+    }
+
+    public void addResetHandler(IResetHandler handler) {
+        resetHandlers.add(handler);
+    }
+
+    private void fireReset() {
+        resetHandlers.forEach(IResetHandler::reset);
     }
 
     private void resetQueue() {
@@ -108,7 +118,7 @@ public class BlueMapAPIConnector {
         if (markerActionQueue.isShutdown()) {
             resetQueue();
 
-            SignManager.reload();
+            fireReset();
         }
 
         this.blueMapAPI = api;

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/IResetHandler.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/IResetHandler.java
@@ -1,0 +1,5 @@
+package com.tpwalke2.bluemapsignmarkers.core.bluemap;
+
+public interface IResetHandler {
+    void reset();
+}

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignManager.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignManager.java
@@ -3,6 +3,7 @@ package com.tpwalke2.bluemapsignmarkers.core.signs;
 import com.tpwalke2.bluemapsignmarkers.Constants;
 import com.tpwalke2.bluemapsignmarkers.config.ConfigManager;
 import com.tpwalke2.bluemapsignmarkers.core.bluemap.BlueMapAPIConnector;
+import com.tpwalke2.bluemapsignmarkers.core.bluemap.IResetHandler;
 import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.ActionFactory;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroup;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupType;
@@ -17,7 +18,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-public class SignManager {
+public class SignManager implements IResetHandler {
     private static SignManager instance;
     private static final Object mutex = new Object();
 
@@ -49,10 +50,6 @@ public class SignManager {
         getInstance().shutdown();
     }
 
-    public static void reload() {
-        getInstance().reloadSigns();
-    }
-
     private final BlueMapAPIConnector blueMapAPIConnector;
     private final ActionFactory actionFactory;
     private final ConcurrentMap<SignEntryKey, SignEntry> signCache = new ConcurrentHashMap<>();
@@ -71,8 +68,9 @@ public class SignManager {
         }
 
         MarkerSetIdentifierCollection markerSetIdentifierCollection = new MarkerSetIdentifierCollection();
-        blueMapAPIConnector = new BlueMapAPIConnector();
         actionFactory = new ActionFactory(markerSetIdentifierCollection);
+        blueMapAPIConnector = new BlueMapAPIConnector();
+        blueMapAPIConnector.addResetHandler(this);
     }
 
     private List<SignEntry> getAllSigns() {
@@ -175,5 +173,10 @@ public class SignManager {
 
     private void removeEntry(SignEntry signEntry) {
         removeByKey(signEntry.key());
+    }
+
+    @Override
+    public void reset() {
+        reloadSigns();
     }
 }


### PR DESCRIPTION
The constructors of `SignManager` and `BlueMapAPIConnector` had a circular dependency. While the `BlueMapAPIConnector` needs access to the `SignManager` instance sometimes, it does not need it at instantiation.

This PR introduces a "reset" event to the `BlueMapAPIConnector` for which the `SignManager` registers as a listener. This decouples the constructors of both classes.