### PR TITLE
#109 Changes sign storage to be sharded by region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ replay_*.log
 # other
 
 logs/
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ hs_err_*.log
 replay_*.log
 *.hprof
 *.jfr
+
+# other
+
+logs/

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ loader_version=0.19.3
 # Mod Properties
 mod_id=bluemapsignmarkers
 mod_name=BlueMap Sign Markers
-mod_version=26.2-0.16.1
+mod_version=26.2-0.17.0
 mod_description=A plugin for BlueMap that creates markers from signs
 maven_group=com.tpwalke2.bluemapsignmarkers
 archives_base_name=bluemapsignmarkers

--- a/plans/codebase-review-2026-07-11.md
+++ b/plans/codebase-review-2026-07-11.md
@@ -1,0 +1,283 @@
+# Codebase review — 2026-07-11
+
+Full-codebase review (not scoped to one change), done by two parallel deep-dive passes: one over the
+sign/config/persistence stack, one over the BlueMap integration/markers/reactive-queue stack. Top findings from
+each were spot-checked directly against the source before inclusion here. Severities: Critical > High > Medium >
+Low > Nitpick.
+
+Findings are review-only — no fixes applied. Ordered by severity within each area.
+
+## Critical
+
+### 1. `getMarkerFilePath` resolves to the working-dir name, not the world/level-save name — breaks per-world isolation
+**`src/main/java/com/tpwalke2/bluemapsignmarkers/BlueMapSignMarkersMod.java:35`**
+```java
+var worldSaveName = server.getWorldPath(LevelResource.ROOT).toAbsolutePath().getParent().getFileName();
+```
+`getWorldPath(LevelResource.ROOT)` already returns the level-save directory itself (e.g. `<run-dir>/world`). The
+extra `.getParent()` steps up to `<run-dir>`, so `.getFileName()` returns the run/working directory's name, not the
+level-name folder. Any server that changes `level-name` in `server.properties` to host a different map from the
+same working directory resolves to the exact same `config/bluemapsignmarkers/<run-dir-name>/signs.json` path —
+directly contradicting the per-world persistence design in AGENTS.md. Confirmed by direct read; looks like an
+accidental extra `.getParent()` hop (the variable name `worldSaveName` implies the level-name folder was intended).
+Verify with `runServer` under two different `level-name` values before fixing.
+
+### 2. `ReactiveQueue.getExecutor()` self-heals a shut-down executor, defeating `shutdown()` and leaking threads
+**`src/main/java/com/tpwalke2/bluemapsignmarkers/core/reactive/ReactiveQueue.java:56-62`**
+```java
+private synchronized ExecutorService getExecutor() {
+    if (isShutdown()) {
+        executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+    }
+    return executor;
+}
+```
+Any caller that finds the executor shut down silently allocates a new one — there's no flag for "this queue is
+intentionally retired," only `executor.isShutdown()`. Trigger: `onDisable()` calls `markerActionQueue.shutdown()`
+while `processMessages()` (line 35-46) is still mid-loop on a worker thread from that same executor. The loop's next
+iteration calls `getExecutor()` again (line 40) to submit the next message, observes `isShutdown()==true`, and
+creates a **fresh** `ExecutorService` — non-daemon threads that nothing ever explicitly shuts down again (the next
+`shutdown()` call only fires on the next `onDisable`, which may be long from now or never). Confirmed by direct
+read. Secondary effect: because a live executor now exists, `onEnable()`'s `if (markerActionQueue.isShutdown())`
+guard (`BlueMapAPIConnector.java:161`) sees `false` on the next enable, so `resetQueue()`/`fireReset()` — the
+intended "replay all signs" recovery path — gets skipped even though the connector went through a disable/enable
+cycle.
+
+## High
+
+### 3. `SignEntryHelper.isMarkerType` NPEs when a persisted sign's prefix isn't in the current config
+**`src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignEntryHelper.java:21`**
+```java
+return prefix != null && prefixGroupMap.get(prefix).type() == markerGroupType;
+```
+No null-check on the map lookup. `prefixGroupMap` is built once from the *current* `BMSM-Core.json`. Every
+`SignEntry` loaded from a persisted `signs.json` carries whatever prefix string was current the last time the file
+was saved. Renaming or removing a marker-group prefix between server restarts — a normal config edit — makes
+`prefixGroupMap.get(prefix)` return `null` for every already-persisted sign using the old prefix, and `.type()`
+throws NPE. Confirmed by direct read. This is the first line evaluated in `SignManager.addOrUpdateSign`, so it
+fires both during `SignProvider.loadSigns`'s startup loop and again live whenever that chunk loads or the sign is
+next edited.
+
+### 4. `SignProvider.loadSigns`'s load loop has no per-entry exception handling — one bad entry drops the whole file
+**`src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignProvider.java:59-61`**
+```java
+for (SignEntry signEntry : signEntries) {
+    SignManager.addOrUpdate(signEntry);
+}
+```
+Combined with finding #3: a single entry with a stale prefix throws an uncaught NPE that aborts the *entire* loop,
+silently dropping every remaining sign in the file for the rest of the session. Only the outermost catch around all
+of `loadSigns` catches it, logging a generic "Failed to load markers from file" with no indication of partial loss.
+Directly conflicts with AGENTS.md's stated guarantee that old `signs.json` files "must keep loading." Same
+all-or-nothing pattern also exists in `Version1SignEntryLoader.java:28-31`.
+
+### 5. Concurrent, unsynchronized mutation of a shared BlueMap marker map
+**`src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java`** — `addMarker` (132-154),
+`updateMarker` (114-125), `removeMarker` (127-130) vs. `getMarkerSets` (175-207, `synchronized`)
+`getMarkerSets(...)` is `synchronized`, but `addMarker`/`updateMarker`/`removeMarker` — which mutate the
+`Map<String, Marker>` returned by `MarkerSet.getMarkers()` — are `static` and not synchronized on anything.
+`ReactiveQueue`'s executor is sized to `availableProcessors()`, so on any multi-core host more than one
+`MarkerAction` can be dispatched to `processMarkerAction` concurrently. Two actions targeting different sign
+positions on the same map + marker group resolve to the same cached `MarkerSet` and thus the same underlying marker
+`Map` instance (whose concrete thread-safety is controlled by BlueMap's API, not this mod). Concurrent
+`put`/`remove`/iteration on that map risks lost updates or corruption during a resize. `getMarkerSets`'s
+`synchronized` only protects lookup/creation of the list reference, not what happens to its contents afterward.
+
+### 6. `Version3Converter` fabricates a prefix for every migrated V2 entry, even non-matching sides
+**`src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/Version3Converter.java:26`**
+```java
+var markerGroup = Arrays.stream(markerGroups).filter(m -> m.type() == MarkerGroupType.POI).findFirst().orElseThrow();
+```
+Verified by reading `SignLinesParseResultV2` (`markerType` is `@Nullable`, no `prefix` field at all) and
+`VersionedFileSignEntryLoader.java:31-33`, which calls `Version3Converter.convertToV3` unconditionally for every
+entry's front **and** back text, regardless of whether `markerType` was null (meaning that side never matched any
+group in the original V1/V2 data). Every migrated sign — including sides that originally matched nothing — gets
+assigned the prefix of whichever `POI`-type `MarkerGroup` happens to be first in the *current* config array. Two
+distinct bugs stack here: (a) blank/non-matching sides spuriously become "matching" after migration, fabricating
+markers that never should have existed, and (b) if more than one POI-type group is configured, every migrated sign
+silently gets reassigned to the first one regardless of which prefix it actually had. `.orElseThrow()` also throws
+an uncaught `NoSuchElementException` if the config has zero POI-type groups (e.g. `"markerGroups": []`), which
+propagates uncaught through the fallback path all the way to `SignProvider`'s outer catch — total loss of all
+persisted signs for the session. (b) alone is already flagged as a known limitation in `agent-context/context/
+config-and-persistence.md`; (a) is a separate, unacknowledged defect found during this review.
+
+### 7. `BlueMapAPIConnector.shutdown()`'s `unregisterListener` calls likely no-op
+**`src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java:41-44`**
+```java
+public void shutdown() {
+    BlueMapAPI.unregisterListener(this::onEnable);
+    BlueMapAPI.unregisterListener(this::onDisable);
+}
+```
+`this::onEnable` evaluated here creates a **new** method-reference object, distinct by identity/default `equals`
+from the `this::onEnable` passed to `BlueMapAPI.onEnable(...)` in the constructor (line 37). Unless
+`BlueMapAPI.unregisterListener` does something other than identity/`equals`-based list removal, this fails to
+detach the connector from BlueMap's callbacks — a "shut down" connector keeps reacting to future enable/disable
+events. Caveat: confirming this needs the BlueMap API's own listener-registration source, which wasn't in the
+review's file set — flagged High rather than Critical for that reason.
+
+### 8. Malformed `REGEX` marker-group prefix throws uncaught, blocking sign processing broadly
+**`src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignLinesParser.java:80-90`**
+`line.matches(markerGroup.prefix())` / `line.replaceAll(markerGroup.prefix(), "")` use the raw config string as a
+regex with zero validation anywhere in the chain — `ConfigProvider` never test-compiles it. A single typo'd regex
+throws `PatternSyntaxException` the first time matching reaches that group, and because groups are tried in
+configured order until one matches, a bad regex placed early can throw for essentially every sign the server
+processes, not just ones meant for that group. Propagates uncaught out of `SignBlockEntityInject`'s `@Inject`
+callback and `BlueMapSignMarkersMod.onBlockEntityLoad`.
+
+## Medium
+
+### 9. `ConfigProvider` misclassifies V2 configs as V1 via raw substring search
+**`src/main/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProvider.java:84`**
+```java
+if (configContent.contains("poiPrefix")) { ... }
+```
+Confirmed by direct read. This is a substring search over the whole file, not a structural check. Any V2 config
+whose JSON text happens to contain `poiPrefix` anywhere (e.g. in a marker-group name/icon) is misclassified as V1;
+`GSON.fromJson(configContent, BMSMConfigV1.class)` binds nothing real, falls back to the default `"[poi]"` prefix,
+and `loadV1Config` overwrites the entire config with a single default POI group via `saveConfig` — discarding all
+real marker groups. A `.v1.bak` backup is made first, so it's recoverable, but the corrupted config no longer
+contains `poiPrefix`, so it won't retrigger — the damage silently sticks unless someone notices.
+
+### 10. No `awaitTermination`; old-generation tasks can straddle a `resetQueue()`/`fireReset()` replay
+**`ReactiveQueue.java:52-54` (`shutdown()`) and `BlueMapAPIConnector.java` `resetQueue()` (58-66) / `onEnable()`
+(160-169)**
+`shutdown()` requests graceful shutdown but never waits for in-flight tasks. `onEnable()` can immediately call
+`resetQueue()` (swapping in new `markerActionQueue`/`markerSetsCache` objects) while a straggling task from the
+previous executor generation is still running `processMarkerAction` against the connector's other shared state. This
+can interleave with `fireReset()`'s full sign-cache replay, causing duplicate adds or a stale remove/add applied
+after the replay already established "correct" state.
+
+### 11. `resetQueue()`/`onEnable()` mutate fields without the lock `getMarkerSets()` synchronizes on
+**`BlueMapAPIConnector.java`** — `resetQueue()` (58-66), `onEnable()` (160-169), vs. `getMarkerSets()` (175,
+`synchronized`)
+Neither `resetQueue()` nor `onEnable()` synchronizes on `this`, so a worker thread inside the synchronized
+`getMarkerSets()` can race with a plain-field reassignment of `markerSetsCache` on another thread — a data race on
+the field reference itself, independent of the map's own thread-safety. Same root cause class as #10.
+
+### 12. `blueMapAPI` / `executor` field visibility — no `volatile`, no happens-before edge
+**`BlueMapAPIConnector.java:167,210`** and **`ReactiveQueue.java:48-50,56-62`**
+`blueMapAPI` is written on the BlueMap callback thread (`onEnable`) and read on `ReactiveQueue` worker threads
+(`getMaps()`) with no synchronization. Same pattern in `ReactiveQueue`: `isShutdown()` reads `executor`
+unsynchronized while `getExecutor()` writes it under `synchronized`. Per JMM neither read is guaranteed to observe
+the latest write — a real (if hard to reproduce) visibility race in both cases.
+
+### 13. `FileUtils.createBackup`/`copyFile` swallow backup failures, then the caller overwrites the original anyway
+**`src/main/java/com/tpwalke2/bluemapsignmarkers/common/FileUtils.java:17-32`**
+`copyFile` catches `IOException` and only logs a warning — it never signals failure back up. Both the V1→V2 config
+migration and the V1/V2→V3 sign-file migration call `createBackup(...)` and then unconditionally overwrite the
+original file on the next line. If the backup silently fails (disk full, permissions), the only copy of the user's
+pre-migration data is gone with no recoverable backup and no visible signal beyond a log line — undermines the
+entire point of backing up before a data-changing migration.
+
+### 14. `SignLinesParser`: REGEX groups can't have a label share the line with the prefix
+**`src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignLinesParser.java:88-90`**
+`getLabel`'s REGEX branch reapplies the same pattern via `replaceAll` that `matches()` requires to match the whole
+line. A pattern strict enough to satisfy whole-line-match without trailing text works (empty label, correct); a
+pattern loosened specifically to allow trailing label text on the prefix line is the only way to make `matches()`
+accept it at all, but then `replaceAll` greedily strips the entire line, including the label — leaving it blank.
+There's no configuration that makes "label on the same line as a REGEX prefix" actually work, and the failure is
+silent. Not covered by any existing test.
+
+### 15. `SignLinesParser.trim()` doesn't recognize non-ASCII invisible whitespace
+**`src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignLinesParser.java:27`**
+`.trim()` misses NBSP (U+00A0), ideographic space (U+3000), zero-width space (U+200B) — all reachable via
+clipboard-paste into a sign. A line consisting solely of one becomes the sign's "first non-blank line," matches no
+marker group, and permanently transitions the parser to `INVALID` — so a genuine `[poi]` line immediately after is
+never reached. A leading invisible character on an otherwise-valid prefix line defeats `startsWith`/most regexes the
+same way, with only a DEBUG log and no other feedback.
+
+### 16. `MarkerSetIdentifierCollection`'s internal collections aren't thread-safe
+**`src/main/java/com/tpwalke2/bluemapsignmarkers/core/markers/MarkerSetIdentifierCollection.java:6-11,34-38`**
+Plain `TreeMap`/`HashMap`/`HashSet`, not concurrent collections. Likely only touched from the single Minecraft
+server thread based on the documented architecture, but that isn't verifiable from this class alone — flagged as an
+open question pending a look at all `ActionFactory` call sites.
+
+### 17. `SignManager.reloadSigns()` races with concurrent live sign edits
+**`src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignManager.java:87-94`**
+`IResetHandler.reset()` fires on `BlueMapAPI.onEnable`, not necessarily the server thread. `reloadSigns` does
+`signCache.clear()` then replays a snapshot of the old values one at a time via `addOrUpdateSign` — not atomic
+against concurrent server-thread mutations from the mixins. A real-time edit/removal mid-reload can be clobbered by
+a stale replayed value, or a sign removed during the race can be silently re-added by the replay.
+
+## Low
+
+- **`SignManager` singleton's double-checked locking is broken — `instance` isn't `volatile`**
+  (`SignManager.java:22`). A thread on the fast path can observe a non-null but not-fully-constructed
+  `SignManager` per allowed JMM reordering. Concrete trigger: `SERVER_STARTING`'s `loadSigns` racing a
+  `BLOCK_ENTITY_LOAD` firing during world load, both hitting `SignManager` for the first time.
+- **`BlueMapSignMarkersMod`: hardcoded `"unknown"` playerId sentinel duplicated, uncoupled from `WorldMap.UNKNOWN`**
+  (`BlueMapSignMarkersMod.java:42`, `SignManager.java:136`). Two independently-hardcoded literals that only happen
+  to match today; editing one without the other silently breaks playerId-preservation logic on chunk load vs.
+  player edit.
+- **`ServerPathProvider.java` is dead code** — no callers anywhere in `src/`, and it's referenced elsewhere as
+  in-progress/unwired. Should be wired up or removed.
+- **Charset mismatch between save and load**, both in `ConfigProvider.java` (`saveConfig` uses platform-default
+  `FileWriter`, `loadConfig` reads explicit UTF-8) and `SignProvider.java` (same pattern). Non-ASCII marker-group
+  names or sign text is at risk of encoding mismatch across a restart if the JVM default charset isn't UTF-8.
+- **No fail-fast config validation** — nothing checks marker-group prefixes are non-empty, that REGEX prefixes
+  compile, or that prefixes are unique across groups at load time; bad data is only caught later, silently or by
+  crashing (see finding #8).
+- **`Version1SignEntryLoader.getNormalizedMapId`** only recognizes exact lowercase `"nether"`/`"end"`/`"overworld"`
+  literals; any other legacy dimension string falls through unchanged, permanently mismatching the live dimension
+  key post-migration and duplicating markers as "new" signs. Unverifiable against the true historical V1 format from
+  files in scope.
+- **`VersionedFileSignEntryLoader`**: a structurally-valid-but-incomplete JSON (missing `version`/`data`) is handled
+  by Gson returning nulls rather than throwing, which happens to funnel into the same V1-fallback path as a genuine
+  parse exception — works today but by coincidence, not design.
+- **`getMarkerSets`'s `putIfAbsent`-inside-per-map-forEach pattern is fragile** (`BlueMapAPIConnector.java:187-204`)
+  — correctness today depends on an implicit, undocumented invariant (shared mutable list + no-op `putIfAbsent` on
+  every iteration after the first) that a future refactor could silently break.
+- **`logProcessingMessage` logs full raw sign text at INFO unconditionally**, sanitizing only `\n`
+  (`BlueMapAPIConnector.java:97-102`) — other control characters (`\r`, ANSI escapes) aren't sanitized, a minor
+  log-injection/log-noise vector.
+- **Cache-key growth risk**: `MarkerSetIdentifier`/`markerSetsCache` keys are value-equality on the *entire*
+  `MarkerGroup` record, so any config field change (icon, offsets, distances) between reloads produces a new,
+  never-evicted cache entry. Speculative — depends on a config-reload path not covered in this review.
+- **`SignManager`: dual-sided signs with different prefixes mix marker-group semantics** — the marker's group
+  (icon/type/visibility) comes from whichever side `getPrefix` picks (front preferred), but `getDetail` merges
+  *both* sides' text regardless of whether they matched different groups.
+- **`SignEntry`'s hand-written `equals`/`hashCode`** have no null-guards on `key`/`playerId`/`frontText`/`backText`;
+  latent only, since no current call site actually calls `SignEntry.equals()`/`hashCode()` (the sign cache is keyed
+  by `SignEntryKey`).
+- **`Version3Converter`/`Version1SignEntryLoader`** have no per-entry exception handling, same all-or-nothing loss
+  pattern as finding #4.
+
+## Nitpick
+
+- `ConfigManager.loadCoreConfig()` is `synchronized` despite being called exactly once from a `static final` field
+  initializer, which the JLS already makes thread-safe — the modifier is misleading, not harmful.
+- The default single-`[poi]`-group literal is duplicated verbatim across `BMSMConfigV2` and `LoadingBMSMConfigV2`
+  with no shared constant.
+- `SignManager.isMarkerType` re-derives `getPrefix(signEntry)` that's already computed a few lines later —
+  redundant, harmless.
+- `MarkerAction` subclasses' `getX/Y/Z` widen `int` to `double` — fine, presumably to match the BlueMap API's
+  positional types.
+- `SignLinesParserTest.java` has no test for a permissive REGEX pattern with trailing label text on the prefix line
+  — worth a test to document/lock in the blank-label behavior from finding #14.
+
+## Verified correct (no action needed)
+
+- **`HtmlUtils.escape`/`toHtmlDetail`** (from the recent #131 fix): escaping order is correct (`&` first, avoiding
+  double-escaping), `escape()` runs before the `\n`→`<br>` substitution as the plan requires, and test coverage in
+  `HtmlUtilsTest.java` matches every case in `plans/html-detail-escaping-plan.md`. Traced the full text path
+  (`ParsingContext` → `SignEntryHelper` → `AddMarkerAction`/`UpdateMarkerAction` → `BlueMapAPIConnector.addMarker`/
+  `updateMarker`) and confirmed `toHtmlDetail` is applied at both and only both call sites that reach a `detail`
+  field — no double-escaping, no gap.
+- **`MarkerGroup`/`MarkerSetIdentifier`/`MarkerIdentifier`** — records, so `equals`/`hashCode` are generated
+  structurally-correct and safe as map keys.
+- **Mixin injection points** (`SignBlockEntityInject`, `AbstractBlockInject`) match their documented intent; no
+  correctness issues found in the injection logic itself.
+- **Resource/stream handling** — all I/O reviewed uses NIO `Files.readString`/`Files.copy` or try-with-resources
+  `FileWriter`; no unclosed-handle leaks found.
+- **`BlueMapAPIConnector`'s two action-dispatch switches** (`processMarkerAction`, `logProcessingMessage`) currently
+  list all three `MarkerAction` subclasses — the AGENTS.md-documented "missing case falls to `default`" risk is real
+  but not currently triggered.
+
+## Open questions requiring follow-up outside this review's scope
+
+- Does `ReactiveQueue.processMessages` submit each message as an independent task to the same executor (implying no
+  ordering guarantee between sequential dispatches, e.g. a prefix-change's remove-then-add)? If so, `SignManager`'s
+  prefix-change branch (dispatching remove then add as two separate calls) may not apply in order under load.
+- Confirm whether `BlueMapAPI.unregisterListener` matches by identity or by some other means, to settle finding #7
+  definitively.

--- a/plans/codebase-review-2026-07-11.md
+++ b/plans/codebase-review-2026-07-11.md
@@ -5,7 +5,8 @@ sign/config/persistence stack, one over the BlueMap integration/markers/reactive
 each were spot-checked directly against the source before inclusion here. Severities: Critical > High > Medium >
 Low > Nitpick.
 
-Findings are review-only — no fixes applied. Ordered by severity within each area.
+Findings were review-only at the time of writing (no fixes applied). Ordered by severity within each area; a
+**Resolved** note is added under a finding once it's fixed.
 
 ## Critical
 
@@ -21,6 +22,12 @@ same working directory resolves to the exact same `config/bluemapsignmarkers/<ru
 directly contradicting the per-world persistence design in AGENTS.md. Confirmed by direct read; looks like an
 accidental extra `.getParent()` hop (the variable name `worldSaveName` implies the level-name folder was intended).
 Verify with `runServer` under two different `level-name` values before fixing.
+
+**Resolved 2026-07-15 (`75b6270`, `#109 Region-sharded sign storage`).** `getMarkerStorageRoot` now calls
+`.toAbsolutePath().normalize()` on the level dir before taking `getParent()`/`getFileName()`, collapsing the `.`
+segment `LevelResource.ROOT` resolves to before stepping up — the missing normalize was the root cause. The old
+buggy formula is deliberately kept, unchanged, as `getLegacyMarkerFilePath`, used only to locate the pre-existing
+single-file `signs.json` for one-time migration. See `agent-context/context/config-and-persistence.md`.
 
 ### 2. `ReactiveQueue.getExecutor()` self-heals a shut-down executor, defeating `shutdown()` and leaking threads
 **`src/main/java/com/tpwalke2/bluemapsignmarkers/core/reactive/ReactiveQueue.java:56-62`**
@@ -70,6 +77,13 @@ silently dropping every remaining sign in the file for the rest of the session. 
 of `loadSigns` catches it, logging a generic "Failed to load markers from file" with no indication of partial loss.
 Directly conflicts with AGENTS.md's stated guarantee that old `signs.json` files "must keep loading." Same
 all-or-nothing pattern also exists in `Version1SignEntryLoader.java:28-31`.
+
+**Resolved 2026-07-15 (`7014f82`, "Apply suggestions from code review").** `SignProvider.loadSigns`'s load loop now
+wraps each `SignManager.addOrUpdate(signEntry)` call in its own try/catch, logging the failing entry's key and
+continuing with the rest of the file instead of aborting. Finding #3 itself (the underlying NPE source in
+`SignEntryHelper.isMarkerType`) is unaddressed — this fix contains the blast radius to one entry rather than
+removing the root cause. `Version1SignEntryLoader.java:28-31`'s same all-or-nothing pattern is also still
+unaddressed.
 
 ### 5. Concurrent, unsynchronized mutation of a shared BlueMap marker map
 **`src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java`** — `addMarker` (132-154),

--- a/plans/region-sharded-sign-persistence-plan.md
+++ b/plans/region-sharded-sign-persistence-plan.md
@@ -1,0 +1,167 @@
+# Region-sharded sign persistence
+
+## Context
+
+Addresses GitHub issue #109.
+
+Signs load fully into memory from one file per world:
+`config/bluemapsignmarkers/<world-save-name>/signs.json`, built by
+`BlueMapSignMarkersMod.getMarkerFilePath` (`src/main/java/com/tpwalke2/bluemapsignmarkers/BlueMapSignMarkersMod.java:34-37`):
+
+```java
+private String getMarkerFilePath(MinecraftServer server) {
+    var worldSaveName = server.getWorldPath(LevelResource.ROOT).toAbsolutePath().getParent().getFileName();
+    return String.format("config/%s/%s/signs.json", Constants.MOD_ID, worldSaveName);
+}
+```
+
+Chunk deletion/regen (external tools, pregen resets, manual region-file deletion) fires no "sign removed"
+event — `BLOCK_ENTITY_LOAD` only adds/updates signs that are actually present when a chunk loads, so a chunk wiped
+between server runs leaves its old sign entries in the cache and their markers on the map forever. Fixing this
+correctly means, on chunk load, asking "which signs do we know about in this chunk?" — cheap only if signs are
+indexed by location. Against today's single flat file (and the flat `ConcurrentMap<SignEntryKey, SignEntry>` it's
+loaded into) that question costs a full scan per chunk load, which doesn't scale on busy servers. This plan is
+groundwork: reorganize on-disk storage by location so the actual reconciliation logic (separate follow-up issue) has
+something cheap to query. It does not implement that reconciliation logic itself.
+
+This also folds in an adjacent fix already on record: `plans/codebase-review-2026-07-11.md` (finding #1) flags that
+`getWorldPath(LevelResource.ROOT)` already resolves to the level-save directory, so the extra `.getParent()` walks
+up to the server root and `.getFileName()` grabs the *run directory's* name, not the level name. Rewriting path
+construction to relocate storage out of `config/` is the natural place to fix this too.
+
+## Goal
+
+Move signs off one global-scan file onto one JSON file per (dimension, 32×32-chunk region), stored at:
+
+```
+{server_root}/bluemapsignmarkers/{level}/{dimension_namespace}/{dimension_path}/r.{regionX}.{regionZ}.json
+```
+
+e.g. `{server_root}/bluemapsignmarkers/world/minecraft/overworld/r.0.0.json`. Existing single-file installs migrate
+automatically on first boot after the update, with the legacy file backed up rather than deleted.
+
+Out of scope: the chunk-load reconciliation logic itself (follow-up issue), and any change to `SignManager`'s
+in-memory `ConcurrentMap<SignEntryKey, SignEntry>` — it stays as-is for point lookups by exact position; a
+region-indexed in-memory view is added alongside the reconciliation feature that will actually consume it, not
+speculatively here. Incremental/eager per-region writes for crash resilience are also out of scope — signs still
+save as a full snapshot at `SERVER_STOPPING`, same as today; a crash between clean shutdowns loses unsaved edits
+regardless of file layout, a pre-existing limitation this plan doesn't change.
+
+## Options considered, not chosen
+
+- **SQLite** — real indexed `WHERE dimension = ? AND regionX = ? AND regionZ = ?` queries, ACID. Rejected:
+  `sqlite-jdbc` bundles native binaries per OS/arch, a real risk for a mod meant to run on arbitrary player-hosted
+  servers (unusual JVMs, ARM hosts); also swaps the existing JSON-version-converter migration model for a SQL
+  schema-migration model, a different maintenance pattern from the rest of the persistence code; loses the
+  "open signs.json in a text editor" debuggability the project currently has.
+- **H2 (pure-Java embedded DB)** — same query benefits as SQLite without the native-library risk. Rejected: still a
+  binary file format, still a new migration model, and a heavier dependency than the problem needs given
+  region-sharded JSON solves the same access pattern with no new dependency at all.
+- **LMDB / MapDB (embedded KV store, spatially-sortable keys)** — memory-mapped, fast range scans. Rejected: LMDB
+  still needs native bindings (same risk as SQLite); MapDB is a more novel/less battle-tested dependency than this
+  problem justifies.
+- **Store by player** — doesn't fit the actual problem. A chunk reset can contain signs owned by many players, so a
+  player-keyed index doesn't shrink the reconciliation query at all; it's a different access axis, useful for a
+  future "list my signs" command, not for this issue.
+- **Chunk-based in-memory index only, no on-disk change** — cheapest possible fix (add a
+  `Map<ChunkPos, Set<SignEntryKey>>` alongside the existing cache, built at load and maintained incrementally).
+  Solves the query-cost half of the problem but not the "everything loads into memory at startup" half, and doesn't
+  address the storage-location/config-folder ask in this issue. Worth keeping in mind as the shape of the future
+  in-memory index, but insufficient alone as the on-disk redesign this issue calls for.
+
+## Chosen approach: region-sharded JSON
+
+Why: region boundaries (32×32 chunks, matching Minecraft's own `.mca` Anvil region-file granularity) are exactly
+the granularity external tools reset or delete at (Chunky, WorldBorder, MCA Selector, manual region-file deletion),
+so "this region's file is gone/changed" maps directly onto "these signs may be stale" — the natural unit for the
+eventual reconciliation feature. It keeps the existing Gson + `VersionedSignFile`/`SignFileVersions` machinery
+completely unchanged in shape: an individual region file is exactly today's versioned envelope
+(`{version: V3, data: "[...]"}`) around the `SignEntry` array for that region — only the *aggregation into many
+files*, not the JSON schema, changes. No new dependency, no native-library risk, still human-readable/greppable.
+
+**Region coordinate math**: `regionX = Math.floorDiv(x, 512)`, `regionZ = Math.floorDiv(z, 512)` (512 = 32 chunks ×
+16 blocks/chunk). Must use `floorDiv`, not integer division — world coordinates go negative and truncating division
+would put e.g. `x = -1` in the same region as `x = 0`.
+
+**Dimension folder**: `SignEntryKey.parentMap` is already a string of the form `namespace:path` (or the
+`WorldMap.UNKNOWN` sentinel `"unknown"`, no colon) — split on the first `:` to get two path segments
+(`namespace`, `path`); no further sanitizing needed since Minecraft identifier characters are already
+filesystem-safe on Windows/Linux/macOS. `unknown` (no colon) becomes a single folder segment with no sub-path.
+
+## Changes
+
+1. **`src/main/java/com/tpwalke2/bluemapsignmarkers/ServerPathProvider.java`** — currently a dead, unimplemented
+   interface (`Path getConfigFolder()`, no implementers, no callers). Repurpose it to own the new base-directory
+   resolution instead of adding a parallel abstraction:
+   ```java
+   Path getMarkerStorageRoot(MinecraftServer server); // {server_root}/bluemapsignmarkers/{level}
+   ```
+   Implementation: `levelDir = server.getWorldPath(LevelResource.ROOT).toAbsolutePath().normalize()`; server root =
+   `levelDir.getParent()`; level name = `levelDir.getFileName()`; result =
+   `serverRoot.resolve(Constants.MOD_ID).resolve(levelName)`. The `.normalize()` is load-bearing, not cosmetic:
+   `LevelResource.ROOT`'s relative path is literally `"."`, and `Path.resolve()` never collapses `.` segments on its
+   own — without normalizing first, `levelDir` keeps an unresolved trailing `.`, which shifts `getParent()`/
+   `getFileName()` by one level (`serverRoot` resolves to the level directory itself instead of the true server
+   root, and `levelName` comes back as `"."` instead of the level name), landing the whole storage root one level
+   too deep, inside the world save folder. Confirm the `LevelResource.ROOT` assumption once via a log line in
+   `runServer` before relying on it, since the whole path change hinges on it.
+2. **New pure-Java class, `core/signs/persistence/SignRegionKey.java`** (record: `String dimension, int regionX,
+   int regionZ`) plus a small partitioning helper (e.g. a static method on `SignProvider` or a new
+   `SignRegionPartitioner`) implementing the region-coordinate math and dimension split above, grouping a
+   `List<SignEntry>` into `Map<SignRegionKey, List<SignEntry>>`. Pure logic, no Minecraft types — unit-testable
+   per the existing `SignLinesParser`/`SignEntryHelper` convention in `AGENTS.md`.
+3. **New loader, `core/signs/persistence/loaders/RegionShardedSignEntryLoader.java`** — given the storage root,
+   walks the `{namespace}/{path}/r.{x}.{z}.json` tree, reads each region file with the same Gson/
+   `VersionedFileSignEntryLoader` deserialization `SignProvider` already uses per-file today, flattens into one
+   `SignEntry` list.
+4. **`core/signs/persistence/SignProvider.java`** — `loadSigns`/`saveSigns` take the storage root (a `Path`, from
+   change #1) instead of a single file path string:
+   - `loadSigns`: if the storage root exists and is non-empty, load via #3. Otherwise run migration (#5).
+   - `saveSigns`: partition `SignManager.getAll()` via #2, write each partition as a `VersionedSignFile{V3, ...}`
+     to its region path (creating parent dirs as needed) — same per-file write logic as today's single file, just
+     once per region. Then delete any region file already on disk under the tree that isn't in this save's
+     partition set (a region that's now empty), so stale empty-shard files don't accumulate.
+5. **Migration** (see dedicated section below) — one-time, triggered when the new storage root doesn't exist yet.
+6. **New tests**, `src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/`:
+   - Region-key math: `floorDiv`-based region assignment is correct for negative coordinates and region boundaries
+     (e.g. `x = -1` vs `x = 0` vs `x = 511` vs `x = 512` land in the expected/different regions).
+   - Dimension-string splitting, including the no-colon `WorldMap.UNKNOWN` case.
+   - Round-trip: write a set of `SignEntry`s spanning multiple regions and dimensions to a `@TempDir`, reload via
+     #3, assert the same entries come back.
+   - Migration: a legacy single-file fixture (V1, V2, and V3 shapes) in the old buggy-path layout migrates to the
+     correct new-layout files, and the legacy file is renamed/backed up rather than deleted.
+7. **`gradle.properties`** — minor `mod_version` bump (`26.2-0.16.1` → `26.2-0.17.0`): default storage location and
+   on-disk layout change for every install (auto-migrated, but a real behavior/location change, not just a bug fix
+   — e.g. any external backup tooling pointed at `config/bluemapsignmarkers/` needs to be repointed).
+
+## Migration considerations
+
+- **Must locate the legacy file using the current (buggy) path formula**, not the fixed one — `getMarkerFilePath`'s
+  existing `.getParent().getFileName()` logic is what's actually on disk on live servers today, so migration has to
+  replicate that exact (wrong) formula to find the old file, not the newly-fixed level-name resolution.
+- **Reuse the existing V1→V2→V3 converter chain unchanged** as migration's first stage — load the legacy file
+  through `VersionedFileSignEntryLoader`/`Version1SignEntryLoader` exactly as `SignProvider.loadSigns` does today,
+  *then* region-partition the resulting flat `SignEntry` list. Region-sharding is a step layered after existing
+  version normalization, not a replacement for it.
+- **Back up, don't delete**, the legacy file — rename/copy it aside (reuse `FileUtils.createBackup`'s pattern,
+  e.g. a `.migrated` suffix) once the new region files are written successfully, consistent with the existing
+  `.v1.bak`/`.v2.bak` convention.
+- **One-shot**: presence of the new storage root (change #1) short-circuits migration on every subsequent boot —
+  no re-migration, no double-processing.
+- **Log the new location** clearly on migration, since storage moved out of `config/` entirely — anyone with
+  backup scripts or manual habits pointed at the old path needs to notice.
+- **Edge cases**: `WorldMap.UNKNOWN` dimension entries (no colon in `parentMap`) need graceful single-segment
+  folder handling; a region that had signs in the legacy file but ends up empty after migration should simply not
+  get a file written, not an empty stub.
+
+## Verification
+
+- `./gradlew test` — new persistence/migration/region-math tests pass alongside existing `SignLinesParserTest`/
+  `HtmlUtilsTest`.
+- `./gradlew build` — full build, including jar packaging, still succeeds.
+- Manual, via `./gradlew runServer`: place signs across multiple regions and at least two dimensions
+  (overworld + nether), restart the server, confirm markers still appear correctly in BlueMap after reload.
+- Manual migration check: start from a dev `run/` directory containing a pre-existing
+  `config/bluemapsignmarkers/<name>/signs.json` fixture (V1, V2, and V3 shaped, in separate test runs), boot the
+  server, confirm the new `bluemapsignmarkers/{level}/...` region files appear with correct contents and the
+  legacy file is backed up in place rather than removed.

--- a/plans/region-sharded-sign-persistence-plan.md
+++ b/plans/region-sharded-sign-persistence-plan.md
@@ -119,8 +119,8 @@ filesystem-safe on Windows/Linux/macOS. `unknown` (no colon) becomes a single fo
    - `loadSigns`: if the storage root exists and is non-empty, load via #3. Otherwise run migration (#5).
    - `saveSigns`: partition `SignManager.getAll()` via #2, write each partition as a `VersionedSignFile{V3, ...}`
      to its region path (creating parent dirs as needed) — same per-file write logic as today's single file, just
-     once per region. Then delete any region file already on disk under the tree that isn't in this save's
-     partition set (a region that's now empty), so stale empty-shard files don't accumulate.
+     once per region. Then quarantine (rename to `*.json.stale`) any region file already on disk under the tree that isn't in this save's
+     partition set (a region that's now empty), so potentially-unloaded data isn't deleted (at the cost of leaving `.stale` files behind).
 5. **Migration** (see dedicated section below) — one-time, triggered when the new storage root doesn't exist yet.
 6. **New tests**, `src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/`:
    - Region-key math: `floorDiv`-based region assignment is correct for negative coordinates and region boundaries

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/BlueMapSignMarkersMod.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/BlueMapSignMarkersMod.java
@@ -12,7 +12,9 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.SignBlockEntity;
 import net.minecraft.world.level.storage.LevelResource;
 
-public class BlueMapSignMarkersMod implements DedicatedServerModInitializer {
+import java.nio.file.Path;
+
+public class BlueMapSignMarkersMod implements DedicatedServerModInitializer, ServerPathProvider {
 
 	@Override
 	public void onInitializeServer() {
@@ -22,16 +24,31 @@ public class BlueMapSignMarkersMod implements DedicatedServerModInitializer {
 	}
 
 	private void onServerStarting(MinecraftServer server) {
-		SignProvider.loadSigns(getMarkerFilePath(server));
+		SignProvider.loadSigns(getMarkerStorageRoot(server), getLegacyMarkerFilePath(server));
 	}
 
 	private void onServerStopping(MinecraftServer server) {
-		SignProvider.saveSigns(getMarkerFilePath(server));
+		SignProvider.saveSigns(getMarkerStorageRoot(server));
 
 		SignManager.stop();
 	}
 
-	private String getMarkerFilePath(MinecraftServer server) {
+	@Override
+	public Path getMarkerStorageRoot(MinecraftServer server) {
+		// normalize() is required: LevelResource.ROOT's relative path is ".", so without it levelDir keeps an
+		// unresolved trailing "." segment, shifting getParent()/getFileName() by one level (serverRoot would
+		// resolve to the level dir itself, and levelName to "." instead of the level name).
+		var levelDir = server.getWorldPath(LevelResource.ROOT).toAbsolutePath().normalize();
+		var serverRoot = levelDir.getParent();
+		var levelName = levelDir.getFileName();
+
+		return serverRoot.resolve(Constants.MOD_ID).resolve(levelName);
+	}
+
+	// Pre-existing (buggy) formula kept as-is: it resolves to the run directory's name, not the level name,
+	// which is exactly what's on disk for every install predating region-sharded storage. Migration needs to
+	// find files at the path they were actually written to, not the corrected one getMarkerStorageRoot uses.
+	private String getLegacyMarkerFilePath(MinecraftServer server) {
 		var worldSaveName = server.getWorldPath(LevelResource.ROOT).toAbsolutePath().getParent().getFileName();
 		return String.format("config/%s/%s/signs.json", Constants.MOD_ID, worldSaveName);
 	}

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/ServerPathProvider.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/ServerPathProvider.java
@@ -1,7 +1,9 @@
 package com.tpwalke2.bluemapsignmarkers;
 
+import net.minecraft.server.MinecraftServer;
+
 import java.nio.file.Path;
 
 public interface ServerPathProvider {
-    Path getConfigFolder();
+    Path getMarkerStorageRoot(MinecraftServer server);
 }

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/common/FileUtils.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/common/FileUtils.java
@@ -23,11 +23,31 @@ public class FileUtils {
         }
     }
 
+    public static void moveToBackup(String originalPath, String suffix, String fileDescription) {
+        var originalFile = new File(originalPath);
+        if (!originalFile.exists()) return;
+
+        var backupPath = originalPath + suffix;
+        var backupFile = new File(backupPath);
+        if (backupFile.exists()) return;
+
+        LOGGER.info("Backing up {}...", fileDescription);
+        moveFile(originalPath, backupPath);
+    }
+
     private static void copyFile(String sourcePath, String destinationPath) {
         try {
             Files.copy(Paths.get(sourcePath), Paths.get(destinationPath));
         } catch (IOException e) {
             LOGGER.warn("Failed to copy {} to {}: {}", sourcePath, destinationPath, e);
+        }
+    }
+
+    private static void moveFile(String sourcePath, String destinationPath) {
+        try {
+            Files.move(Paths.get(sourcePath), Paths.get(destinationPath));
+        } catch (IOException e) {
+            LOGGER.warn("Failed to move {} to {}: {}", sourcePath, destinationPath, e);
         }
     }
 }

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/LegacySignFileMigrator.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/LegacySignFileMigrator.java
@@ -1,0 +1,56 @@
+package com.tpwalke2.bluemapsignmarkers.core.signs.persistence;
+
+import com.google.gson.Gson;
+import com.tpwalke2.bluemapsignmarkers.Constants;
+import com.tpwalke2.bluemapsignmarkers.common.FileUtils;
+import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroup;
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignEntry;
+import com.tpwalke2.bluemapsignmarkers.core.signs.persistence.loaders.Version1SignEntryLoader;
+import com.tpwalke2.bluemapsignmarkers.core.signs.persistence.loaders.VersionedFileSignEntryLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+public class LegacySignFileMigrator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Constants.MOD_ID);
+
+    private LegacySignFileMigrator() {
+    }
+
+    public static List<SignEntry> migrate(String legacyPath, Path storageRoot, MarkerGroup[] markerGroups, Gson gson) {
+        var legacyFile = Path.of(legacyPath);
+        if (!Files.exists(legacyFile)) {
+            LOGGER.info("No legacy markers file found at {}, starting fresh", legacyPath);
+            return List.of();
+        }
+
+        LOGGER.info("Migrating legacy markers file {} to region-sharded storage at {}...", legacyPath, storageRoot);
+
+        String legacyContent;
+        try {
+            legacyContent = Files.readString(legacyFile, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            LOGGER.error("Failed to read legacy markers file {}", legacyPath, e);
+            return List.of();
+        }
+
+        var signEntries = VersionedFileSignEntryLoader.loadSignEntries(legacyPath, legacyContent, markerGroups, gson);
+        if (signEntries == null) {
+            signEntries = Version1SignEntryLoader.loadSignEntries(legacyPath, legacyContent, markerGroups, gson);
+        }
+
+        var entryList = Arrays.asList(signEntries);
+        RegionShardedSignEntryWriter.write(storageRoot, entryList, gson);
+        FileUtils.moveToBackup(legacyPath, ".migrated", "legacy markers file");
+
+        LOGGER.info("Migration complete, {} sign(s) now stored under {}", entryList.size(), storageRoot);
+
+        return entryList;
+    }
+}

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/LegacySignFileMigrator.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/LegacySignFileMigrator.java
@@ -60,10 +60,15 @@ public class LegacySignFileMigrator {
         RegionShardedSignEntryWriter.write(storageRoot, entryList, gson);
 
         // Back up the legacy file once migration is complete (or immediately if it contained zero entries).
-        if (entryList.isEmpty() || com.tpwalke2.bluemapsignmarkers.core.signs.persistence.loaders.RegionShardedSignEntryLoader.hasSignData(storageRoot)) {
+        var expectedRegionFiles = SignRegionPartitioner.partition(entryList).keySet().stream()
+                .map(key -> storageRoot.resolve(key.relativeFilePath()))
+                .toList();
+        var migrationWroteAllRegions = entryList.isEmpty() || expectedRegionFiles.stream().allMatch(Files::exists);
+
+        if (migrationWroteAllRegions) {
             FileUtils.moveToBackup(legacyPath, ".migrated", "legacy markers file");
         } else {
-            LOGGER.error("Migration wrote no region files under {}; leaving legacy file in place at {}", storageRoot, legacyPath);
+            LOGGER.error("Migration failed to write one or more region files under {}; leaving legacy file in place at {}", storageRoot, legacyPath);
         }
 
         LOGGER.info("Migration complete, {} sign(s) now stored under {}", entryList.size(), storageRoot);

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/LegacySignFileMigrator.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/LegacySignFileMigrator.java
@@ -40,14 +40,31 @@ public class LegacySignFileMigrator {
             return List.of();
         }
 
-        var signEntries = VersionedFileSignEntryLoader.loadSignEntries(legacyPath, legacyContent, markerGroups, gson);
+        SignEntry[] signEntries;
+        try {
+            signEntries = VersionedFileSignEntryLoader.loadSignEntries(legacyPath, legacyContent, markerGroups, gson);
+            if (signEntries == null) {
+                signEntries = Version1SignEntryLoader.loadSignEntries(legacyPath, legacyContent, markerGroups, gson);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Failed to parse legacy markers file {}, leaving it in place", legacyPath, e);
+            return List.of();
+        }
+
         if (signEntries == null) {
-            signEntries = Version1SignEntryLoader.loadSignEntries(legacyPath, legacyContent, markerGroups, gson);
+            LOGGER.error("Legacy markers file {} is not a recognized format; leaving it in place", legacyPath);
+            return List.of();
         }
 
         var entryList = Arrays.asList(signEntries);
         RegionShardedSignEntryWriter.write(storageRoot, entryList, gson);
-        FileUtils.moveToBackup(legacyPath, ".migrated", "legacy markers file");
+
+        // Only back up the legacy file once we're confident something was written.
+        if (entryList.isEmpty() || com.tpwalke2.bluemapsignmarkers.core.signs.persistence.loaders.RegionShardedSignEntryLoader.hasSignData(storageRoot)) {
+            FileUtils.moveToBackup(legacyPath, ".migrated", "legacy markers file");
+        } else {
+            LOGGER.error("Migration wrote no region files under {}; leaving legacy file in place at {}", storageRoot, legacyPath);
+        }
 
         LOGGER.info("Migration complete, {} sign(s) now stored under {}", entryList.size(), storageRoot);
 

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/LegacySignFileMigrator.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/LegacySignFileMigrator.java
@@ -59,7 +59,7 @@ public class LegacySignFileMigrator {
         var entryList = Arrays.asList(signEntries);
         RegionShardedSignEntryWriter.write(storageRoot, entryList, gson);
 
-        // Only back up the legacy file once we're confident something was written.
+        // Back up the legacy file once migration is complete (or immediately if it contained zero entries).
         if (entryList.isEmpty() || com.tpwalke2.bluemapsignmarkers.core.signs.persistence.loaders.RegionShardedSignEntryLoader.hasSignData(storageRoot)) {
             FileUtils.moveToBackup(legacyPath, ".migrated", "legacy markers file");
         } else {

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryWriter.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryWriter.java
@@ -22,29 +22,48 @@ public class RegionShardedSignEntryWriter {
     private RegionShardedSignEntryWriter() {
     }
 
-    public static void write(Path storageRoot, List<SignEntry> signEntries, Gson gson) {
-        var partitions = SignRegionPartitioner.partition(signEntries);
+public static void write(Path storageRoot, List<SignEntry> signEntries, Gson gson) {
+    var partitions = SignRegionPartitioner.partition(signEntries);
 
-        var writtenFiles = new HashSet<Path>();
-        for (var partition : partitions.entrySet()) {
-            var filePath = storageRoot.resolve(partition.getKey().relativeFilePath());
-            writeRegionFile(filePath, partition.getValue(), gson);
-            writtenFiles.add(filePath);
-        }
+    var writtenFiles = new HashSet<Path>();
+    var hadWriteFailures = false;
 
-        quarantineStaleRegionFiles(storageRoot, writtenFiles);
-    }
-
-    private static void writeRegionFile(Path filePath, List<SignEntry> signEntries, Gson gson) {
+    for (var partition : partitions.entrySet()) {
+        Path filePath;
         try {
-            Files.createDirectories(filePath.getParent());
-            var signEntryData = gson.toJson(signEntries);
-            var json = gson.toJson(new VersionedSignFile(SignFileVersions.V3, signEntryData));
-            Files.writeString(filePath, json, StandardCharsets.UTF_8);
-        } catch (IOException e) {
-            LOGGER.error("Failed to write region file {}", filePath, e);
+            filePath = storageRoot.resolve(partition.getKey().relativeFilePath());
+        } catch (IllegalArgumentException e) {
+            hadWriteFailures = true;
+            LOGGER.error("Failed to resolve storage path for region key {}; skipping this partition", partition.getKey(), e);
+            continue;
+        }
+
+        if (writeRegionFile(filePath, partition.getValue(), gson)) {
+            writtenFiles.add(filePath);
+        } else {
+            hadWriteFailures = true;
         }
     }
+
+    if (!hadWriteFailures) {
+        quarantineStaleRegionFiles(storageRoot, writtenFiles);
+    } else {
+        LOGGER.warn("One or more region files failed to write; skipping stale-file quarantine under {}", storageRoot);
+    }
+}
+
+private static boolean writeRegionFile(Path filePath, List<SignEntry> signEntries, Gson gson) {
+    try {
+        Files.createDirectories(filePath.getParent());
+        var signEntryData = gson.toJson(signEntries);
+        var json = gson.toJson(new VersionedSignFile(SignFileVersions.V3, signEntryData));
+        Files.writeString(filePath, json, StandardCharsets.UTF_8);
+        return true;
+    } catch (IOException e) {
+        LOGGER.error("Failed to write region file {}", filePath, e);
+        return false;
+    }
+}
 
     // A region absent from writtenFiles may be genuinely empty, or may have failed to load at
     // startup - can't tell which here, so quarantine instead of delete to avoid losing real data.

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryWriter.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryWriter.java
@@ -1,0 +1,68 @@
+package com.tpwalke2.bluemapsignmarkers.core.signs.persistence;
+
+import com.google.gson.Gson;
+import com.tpwalke2.bluemapsignmarkers.Constants;
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class RegionShardedSignEntryWriter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Constants.MOD_ID);
+
+    private RegionShardedSignEntryWriter() {
+    }
+
+    public static void write(Path storageRoot, List<SignEntry> signEntries, Gson gson) {
+        var partitions = SignRegionPartitioner.partition(signEntries);
+
+        var writtenFiles = new HashSet<Path>();
+        for (var partition : partitions.entrySet()) {
+            var filePath = storageRoot.resolve(partition.getKey().relativeFilePath());
+            writeRegionFile(filePath, partition.getValue(), gson);
+            writtenFiles.add(filePath);
+        }
+
+        deleteStaleRegionFiles(storageRoot, writtenFiles);
+    }
+
+    private static void writeRegionFile(Path filePath, List<SignEntry> signEntries, Gson gson) {
+        try {
+            Files.createDirectories(filePath.getParent());
+            var signEntryData = gson.toJson(signEntries);
+            var json = gson.toJson(new VersionedSignFile(SignFileVersions.V3, signEntryData));
+            Files.writeString(filePath, json, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            LOGGER.error("Failed to write region file {}", filePath, e);
+        }
+    }
+
+    private static void deleteStaleRegionFiles(Path storageRoot, Set<Path> writtenFiles) {
+        if (!Files.isDirectory(storageRoot)) return;
+
+        try (var existing = Files.walk(storageRoot)) {
+            existing.filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".json"))
+                    .filter(path -> !writtenFiles.contains(path))
+                    .forEach(RegionShardedSignEntryWriter::deleteQuietly);
+        } catch (IOException e) {
+            LOGGER.error("Failed to clean up stale region files under {}", storageRoot, e);
+        }
+    }
+
+    private static void deleteQuietly(Path path) {
+        try {
+            Files.delete(path);
+            LOGGER.debug("Removed stale region file {}", path);
+        } catch (IOException e) {
+            LOGGER.warn("Failed to delete stale region file {}", path, e);
+        }
+    }
+}

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryWriter.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryWriter.java
@@ -32,7 +32,7 @@ public class RegionShardedSignEntryWriter {
             writtenFiles.add(filePath);
         }
 
-        deleteStaleRegionFiles(storageRoot, writtenFiles);
+        quarantineStaleRegionFiles(storageRoot, writtenFiles);
     }
 
     private static void writeRegionFile(Path filePath, List<SignEntry> signEntries, Gson gson) {
@@ -48,7 +48,7 @@ public class RegionShardedSignEntryWriter {
 
     // A region absent from writtenFiles may be genuinely empty, or may have failed to load at
     // startup - can't tell which here, so quarantine instead of delete to avoid losing real data.
-    private static void deleteStaleRegionFiles(Path storageRoot, Set<Path> writtenFiles) {
+    private static void quarantineStaleRegionFiles(Path storageRoot, Set<Path> writtenFiles) {
         if (!Files.isDirectory(storageRoot)) return;
 
         try (var existing = Files.walk(storageRoot)) {

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryWriter.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryWriter.java
@@ -10,12 +10,14 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 public class RegionShardedSignEntryWriter {
     private static final Logger LOGGER = LoggerFactory.getLogger(Constants.MOD_ID);
+    private static final String STALE_SUFFIX = ".stale";
 
     private RegionShardedSignEntryWriter() {
     }
@@ -44,6 +46,8 @@ public class RegionShardedSignEntryWriter {
         }
     }
 
+    // A region absent from writtenFiles may be genuinely empty, or may have failed to load at
+    // startup - can't tell which here, so quarantine instead of delete to avoid losing real data.
     private static void deleteStaleRegionFiles(Path storageRoot, Set<Path> writtenFiles) {
         if (!Files.isDirectory(storageRoot)) return;
 
@@ -54,18 +58,20 @@ public class RegionShardedSignEntryWriter {
                         return name.startsWith("r.") && name.endsWith(".json");
                     })
                     .filter(path -> !writtenFiles.contains(path))
-                    .forEach(RegionShardedSignEntryWriter::deleteQuietly);
+                    .forEach(RegionShardedSignEntryWriter::quarantineStaleFile);
         } catch (IOException e) {
             LOGGER.error("Failed to clean up stale region files under {}", storageRoot, e);
         }
     }
 
-    private static void deleteQuietly(Path path) {
+    private static void quarantineStaleFile(Path path) {
+        var stalePath = path.resolveSibling(path.getFileName() + STALE_SUFFIX);
         try {
-            Files.delete(path);
-            LOGGER.debug("Removed stale region file {}", path);
+            Files.move(path, stalePath, StandardCopyOption.REPLACE_EXISTING);
+            LOGGER.warn("Region file {} had no signs in memory; moved it to {} instead of deleting, " +
+                    "in case it failed to load rather than being genuinely empty", path, stalePath);
         } catch (IOException e) {
-            LOGGER.warn("Failed to delete stale region file {}", path, e);
+            LOGGER.warn("Failed to quarantine stale region file {}", path, e);
         }
     }
 }

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryWriter.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryWriter.java
@@ -49,7 +49,10 @@ public class RegionShardedSignEntryWriter {
 
         try (var existing = Files.walk(storageRoot)) {
             existing.filter(Files::isRegularFile)
-                    .filter(path -> path.toString().endsWith(".json"))
+                    .filter(path -> {
+                        var name = path.getFileName().toString();
+                        return name.startsWith("r.") && name.endsWith(".json");
+                    })
                     .filter(path -> !writtenFiles.contains(path))
                     .forEach(RegionShardedSignEntryWriter::deleteQuietly);
         } catch (IOException e) {

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignProvider.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignProvider.java
@@ -33,7 +33,11 @@ public class SignProvider {
                     : LegacySignFileMigrator.migrate(legacyPath, storageRoot, groups, GSON);
 
             for (SignEntry signEntry : signEntries) {
-                SignManager.addOrUpdate(signEntry);
+                try {
+                    SignManager.addOrUpdate(signEntry);
+                } catch (Exception entryException) {
+                    LOGGER.error("Failed to load sign entry {}", signEntry.key(), entryException);
+                }
             }
         } catch (Exception e) {
             LOGGER.error("Failed to load markers", e);

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignProvider.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignProvider.java
@@ -7,17 +7,11 @@ import com.tpwalke2.bluemapsignmarkers.Constants;
 import com.tpwalke2.bluemapsignmarkers.config.ConfigManager;
 import com.tpwalke2.bluemapsignmarkers.core.signs.SignEntry;
 import com.tpwalke2.bluemapsignmarkers.core.signs.SignManager;
-import com.tpwalke2.bluemapsignmarkers.core.signs.persistence.loaders.Version1SignEntryLoader;
-import com.tpwalke2.bluemapsignmarkers.core.signs.persistence.loaders.VersionedFileSignEntryLoader;
+import com.tpwalke2.bluemapsignmarkers.core.signs.persistence.loaders.RegionShardedSignEntryLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 public class SignProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(Constants.MOD_ID);
@@ -28,63 +22,27 @@ public class SignProvider {
     private SignProvider() {
     }
 
-    public static void loadSigns(String path) {
-        LOGGER.info("Loading markers from file: {}...", path);
-
-        var file = new File(path);
-        if (!file.exists()) {
-            LOGGER.info("Markers file does not yet exist, skipping...");
-            return;
-        }
-
-        String signsContent;
-        try {
-            signsContent = Files.readString(file.toPath(), StandardCharsets.UTF_8);
-        } catch (IOException e) {
-            LOGGER.error("Failed to read markers file", e);
-            return;
-        }
+    public static void loadSigns(Path storageRoot, String legacyPath) {
+        LOGGER.info("Loading markers from {}...", storageRoot);
 
         try {
             var groups = ConfigManager.get().getMarkerGroups();
 
-            // versioned file attempt
-            var signEntries = VersionedFileSignEntryLoader.loadSignEntries(path, signsContent, groups, GSON);
-
-            // version 1 attempt
-            if (signEntries == null) {
-                signEntries = Version1SignEntryLoader.loadSignEntries(path, signsContent, groups, GSON);
-            }
+            var signEntries = RegionShardedSignEntryLoader.hasSignData(storageRoot)
+                    ? RegionShardedSignEntryLoader.loadSignEntries(storageRoot, groups, GSON)
+                    : LegacySignFileMigrator.migrate(legacyPath, storageRoot, groups, GSON);
 
             for (SignEntry signEntry : signEntries) {
                 SignManager.addOrUpdate(signEntry);
             }
         } catch (Exception e) {
-            LOGGER.error("Failed to load markers from file", e);
+            LOGGER.error("Failed to load markers", e);
         }
     }
 
-    public static void saveSigns(String path) {
-        LOGGER.info("Saving markers to file: {}...", path);
+    public static void saveSigns(Path storageRoot) {
+        LOGGER.info("Saving markers to {}...", storageRoot);
 
-        var file = new File(path);
-        var parent = file.getParentFile();
-        if (!parent.exists()) {
-            try {
-                Files.createDirectories(Paths.get(parent.getAbsolutePath()));
-            } catch (IOException e) {
-                LOGGER.error("Failed to create parent directories for markers file", e);
-                return;
-            }
-        }
-
-        var signEntries = SignManager.getAll();
-        var signEntryData = GSON.toJson(signEntries);
-
-        try (FileWriter writer = new FileWriter(path)) {
-            GSON.toJson(new VersionedSignFile(SignFileVersions.V3, signEntryData), writer);
-        } catch (Exception e) {
-            LOGGER.error("Failed to save markers to file", e);
-        }
+        RegionShardedSignEntryWriter.write(storageRoot, SignManager.getAll(), GSON);
     }
 }

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignRegionKey.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignRegionKey.java
@@ -23,8 +23,9 @@ public record SignRegionKey(String dimension, int regionX, int regionZ) {
             throw new IllegalArgumentException("Invalid dimension namespace: " + namespace);
         }
 
-        var relativeDir = Path.of(namespace).resolve(rawPath).normalize();
-        if (relativeDir.isAbsolute() || relativeDir.startsWith("..")) {
+        var namespaceDir = Path.of(namespace);
+        var relativeDir = namespaceDir.resolve(rawPath).normalize();
+        if (relativeDir.isAbsolute() || relativeDir.startsWith("..") || !relativeDir.startsWith(namespaceDir)) {
             throw new IllegalArgumentException("Unsafe dimension id for storage path: " + dimension);
         }
 

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignRegionKey.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignRegionKey.java
@@ -16,9 +16,18 @@ public record SignRegionKey(String dimension, int regionX, int regionZ) {
     public Path relativeFilePath() {
         var separatorIndex = dimension.indexOf(':');
         var namespace = separatorIndex < 0 ? dimension : dimension.substring(0, separatorIndex);
-        var path = separatorIndex < 0 ? "" : dimension.substring(separatorIndex + 1);
+        var rawPath = separatorIndex < 0 ? "" : dimension.substring(separatorIndex + 1);
         var fileName = "r." + regionX + "." + regionZ + ".json";
 
-        return path.isEmpty() ? Path.of(namespace, fileName) : Path.of(namespace, path, fileName);
+        if (namespace.isBlank() || namespace.equals(".") || namespace.equals("..")) {
+            throw new IllegalArgumentException("Invalid dimension namespace: " + namespace);
+        }
+
+        var relativeDir = Path.of(namespace).resolve(rawPath).normalize();
+        if (relativeDir.isAbsolute() || relativeDir.startsWith("..")) {
+            throw new IllegalArgumentException("Unsafe dimension id for storage path: " + dimension);
+        }
+
+        return relativeDir.resolve(fileName);
     }
 }

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignRegionKey.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignRegionKey.java
@@ -1,0 +1,24 @@
+package com.tpwalke2.bluemapsignmarkers.core.signs.persistence;
+
+import java.nio.file.Path;
+
+public record SignRegionKey(String dimension, int regionX, int regionZ) {
+    // 32x32 chunks * 16 blocks/chunk, matching Minecraft's own Anvil (.mca) region size.
+    private static final int REGION_SIZE_BLOCKS = 512;
+
+    public static SignRegionKey forPosition(String dimension, int x, int z) {
+        return new SignRegionKey(
+                dimension,
+                Math.floorDiv(x, REGION_SIZE_BLOCKS),
+                Math.floorDiv(z, REGION_SIZE_BLOCKS));
+    }
+
+    public Path relativeFilePath() {
+        var separatorIndex = dimension.indexOf(':');
+        var namespace = separatorIndex < 0 ? dimension : dimension.substring(0, separatorIndex);
+        var path = separatorIndex < 0 ? "" : dimension.substring(separatorIndex + 1);
+        var fileName = "r." + regionX + "." + regionZ + ".json";
+
+        return path.isEmpty() ? Path.of(namespace, fileName) : Path.of(namespace, path, fileName);
+    }
+}

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignRegionPartitioner.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignRegionPartitioner.java
@@ -1,0 +1,25 @@
+package com.tpwalke2.bluemapsignmarkers.core.signs.persistence;
+
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignEntry;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SignRegionPartitioner {
+    private SignRegionPartitioner() {
+    }
+
+    public static Map<SignRegionKey, List<SignEntry>> partition(List<SignEntry> signEntries) {
+        var result = new LinkedHashMap<SignRegionKey, List<SignEntry>>();
+
+        for (var signEntry : signEntries) {
+            var key = signEntry.key();
+            var regionKey = SignRegionKey.forPosition(key.parentMap(), key.x(), key.z());
+            result.computeIfAbsent(regionKey, unused -> new ArrayList<>()).add(signEntry);
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/RegionShardedSignEntryLoader.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/RegionShardedSignEntryLoader.java
@@ -26,10 +26,10 @@ public class RegionShardedSignEntryLoader {
 
         try (var files = Files.walk(storageRoot)) {
             return files.anyMatch(RegionShardedSignEntryLoader::isRegionFile);
-        } catch (IOException e) {
-            LOGGER.error("Failed to inspect markers storage directory {}", storageRoot, e);
-            return false;
-        }
+} catch (IOException e) {
+    LOGGER.error("Failed to inspect markers storage directory {}; assuming it contains sign data to avoid triggering legacy migration", storageRoot, e);
+    return true;
+}
     }
 
     public static List<SignEntry> loadSignEntries(Path storageRoot, MarkerGroup[] markerGroups, Gson gson) {

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/RegionShardedSignEntryLoader.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/RegionShardedSignEntryLoader.java
@@ -1,0 +1,65 @@
+package com.tpwalke2.bluemapsignmarkers.core.signs.persistence.loaders;
+
+import com.google.gson.Gson;
+import com.tpwalke2.bluemapsignmarkers.Constants;
+import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroup;
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class RegionShardedSignEntryLoader {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Constants.MOD_ID);
+
+    private RegionShardedSignEntryLoader() {
+    }
+
+    public static boolean hasSignData(Path storageRoot) {
+        if (!Files.isDirectory(storageRoot)) return false;
+
+        try (var files = Files.walk(storageRoot)) {
+            return files.anyMatch(RegionShardedSignEntryLoader::isRegionFile);
+        } catch (IOException e) {
+            LOGGER.error("Failed to inspect markers storage directory {}", storageRoot, e);
+            return false;
+        }
+    }
+
+    public static List<SignEntry> loadSignEntries(Path storageRoot, MarkerGroup[] markerGroups, Gson gson) {
+        var result = new ArrayList<SignEntry>();
+
+        try (var files = Files.walk(storageRoot)) {
+            var regionFiles = files.filter(RegionShardedSignEntryLoader::isRegionFile).sorted().toList();
+            for (var regionFile : regionFiles) {
+                loadRegionFile(regionFile, markerGroups, gson, result);
+            }
+        } catch (IOException e) {
+            LOGGER.error("Failed to walk markers storage directory {}", storageRoot, e);
+        }
+
+        return result;
+    }
+
+    private static void loadRegionFile(Path regionFile, MarkerGroup[] markerGroups, Gson gson, List<SignEntry> result) {
+        try {
+            var content = Files.readString(regionFile, StandardCharsets.UTF_8);
+            var signEntries = VersionedFileSignEntryLoader.loadSignEntries(regionFile.toString(), content, markerGroups, gson);
+            if (signEntries != null) {
+                result.addAll(Arrays.asList(signEntries));
+            }
+        } catch (IOException e) {
+            LOGGER.error("Failed to read region file {}", regionFile, e);
+        }
+    }
+
+    private static boolean isRegionFile(Path path) {
+        return Files.isRegularFile(path) && path.toString().endsWith(".json");
+    }
+}

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/RegionShardedSignEntryLoader.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/RegionShardedSignEntryLoader.java
@@ -60,6 +60,8 @@ public class RegionShardedSignEntryLoader {
     }
 
     private static boolean isRegionFile(Path path) {
-        return Files.isRegularFile(path) && path.toString().endsWith(".json");
+        if (!Files.isRegularFile(path)) return false;
+        var name = path.getFileName().toString();
+        return name.startsWith("r.") && name.endsWith(".json");
     }
 }

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/LegacySignFileMigratorTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/LegacySignFileMigratorTest.java
@@ -1,0 +1,108 @@
+package com.tpwalke2.bluemapsignmarkers.core.signs.persistence;
+
+import com.google.gson.Gson;
+import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroup;
+import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupMatchType;
+import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupType;
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignEntry;
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignEntryKey;
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignLinesParseResult;
+import com.tpwalke2.bluemapsignmarkers.core.signs.persistence.loaders.RegionShardedSignEntryLoader;
+import com.tpwalke2.bluemapsignmarkers.core.signs.persistence.models.MarkerTypeV2;
+import com.tpwalke2.bluemapsignmarkers.core.signs.persistence.models.SignEntryV2;
+import com.tpwalke2.bluemapsignmarkers.core.signs.persistence.models.SignLinesParseResultV2;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LegacySignFileMigratorTest {
+
+    private static final Gson GSON = new Gson();
+    private static final MarkerGroup[] NO_GROUPS = new MarkerGroup[0];
+
+    @Test
+    void returnsEmptyListAndWritesNothingWhenNoLegacyFileExists(@TempDir Path tempDir) {
+        var legacyPath = tempDir.resolve("signs.json").toString();
+        var storageRoot = tempDir.resolve("storage");
+
+        var result = LegacySignFileMigrator.migrate(legacyPath, storageRoot, NO_GROUPS, GSON);
+
+        assertEquals(List.of(), result);
+        assertFalse(RegionShardedSignEntryLoader.hasSignData(storageRoot));
+    }
+
+    @Test
+    void migratesAV3LegacyFileAndBacksItUpWithoutDeletingIt(@TempDir Path tempDir) throws IOException {
+        var legacyPath = tempDir.resolve("signs.json").toString();
+        var storageRoot = tempDir.resolve("storage");
+        var entry = signEntry(0, 0, "minecraft:overworld", "Town Hall");
+        writeLegacyV3File(legacyPath, entry);
+
+        var result = LegacySignFileMigrator.migrate(legacyPath, storageRoot, NO_GROUPS, GSON);
+
+        assertEquals(List.of(entry), result);
+        assertTrue(RegionShardedSignEntryLoader.hasSignData(storageRoot));
+        assertEquals(
+                List.of(entry),
+                RegionShardedSignEntryLoader.loadSignEntries(storageRoot, NO_GROUPS, GSON));
+
+        assertFalse(Files.exists(Path.of(legacyPath)), "legacy file should be moved, not left in place");
+        assertTrue(Files.exists(Path.of(legacyPath + ".migrated")), "legacy file should be backed up, not deleted");
+    }
+
+    @Test
+    void migratesALegacyV1FileFabricatingPrefixFromThePOIGroup(@TempDir Path tempDir) throws IOException {
+        var legacyPath = tempDir.resolve("signs.json").toString();
+        var storageRoot = tempDir.resolve("storage");
+        var poiGroup = new MarkerGroup(
+                "[poi]", MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI,
+                "Points of Interest", null, 0, 0, false, 0.0, 10000000.0);
+
+        // Already-namespaced dimension string: Version1SignEntryLoader's legacy-shorthand ("overworld"/"nether"/
+        // "end") normalization branch reaches into net.minecraft.world.level.Level's static constants, which
+        // require a running Minecraft bootstrap and aren't available under plain JUnit - not exercised here.
+        writeLegacyV1File(legacyPath, "minecraft:overworld", "Town Hall");
+
+        var result = LegacySignFileMigrator.migrate(legacyPath, storageRoot, new MarkerGroup[]{poiGroup}, GSON);
+
+        assertEquals(1, result.size());
+        var migrated = result.get(0);
+        assertEquals("minecraft:overworld", migrated.key().parentMap());
+        assertEquals("[poi]", migrated.frontText().prefix());
+        assertEquals("Town Hall", migrated.frontText().label());
+        assertTrue(Files.exists(Path.of(legacyPath + ".migrated")));
+    }
+
+    private static void writeLegacyV3File(String path, SignEntry... entries) throws IOException {
+        var data = GSON.toJson(entries);
+        var content = GSON.toJson(new VersionedSignFile(SignFileVersions.V3, data));
+        Files.writeString(Path.of(path), content, StandardCharsets.UTF_8);
+    }
+
+    private static void writeLegacyV1File(String path, String legacyDimension, String label) throws IOException {
+        var entry = new SignEntryV2(
+                new SignEntryKey(0, 64, 0, legacyDimension),
+                "unknown",
+                new SignLinesParseResultV2(MarkerTypeV2.POI, label, label),
+                new SignLinesParseResultV2(null, "", ""));
+        var content = GSON.toJson(new SignEntryV2[]{entry});
+        Files.writeString(Path.of(path), content, StandardCharsets.UTF_8);
+    }
+
+    private static SignEntry signEntry(int x, int z, String dimension, String label) {
+        return new SignEntry(
+                new SignEntryKey(x, 64, z, dimension),
+                "unknown",
+                new SignLinesParseResult("[poi]", label, label),
+                new SignLinesParseResult(null, "", ""));
+    }
+}

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryLoaderTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryLoaderTest.java
@@ -1,0 +1,68 @@
+package com.tpwalke2.bluemapsignmarkers.core.signs.persistence;
+
+import com.google.gson.Gson;
+import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroup;
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignEntry;
+import com.tpwalke2.bluemapsignmarkers.core.signs.persistence.loaders.RegionShardedSignEntryLoader;
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignEntryKey;
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignLinesParseResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RegionShardedSignEntryLoaderTest {
+
+    private static final Gson GSON = new Gson();
+    private static final MarkerGroup[] NO_GROUPS = new MarkerGroup[0];
+
+    @Test
+    void hasSignDataIsFalseWhenStorageRootDoesNotExist(@TempDir Path tempDir) {
+        var missingRoot = tempDir.resolve("does-not-exist");
+
+        assertFalse(RegionShardedSignEntryLoader.hasSignData(missingRoot));
+    }
+
+    @Test
+    void hasSignDataIsFalseWhenStorageRootIsEmpty(@TempDir Path storageRoot) {
+        assertFalse(RegionShardedSignEntryLoader.hasSignData(storageRoot));
+    }
+
+    @Test
+    void hasSignDataIsTrueOnceARegionFileExists(@TempDir Path storageRoot) {
+        RegionShardedSignEntryWriter.write(
+                storageRoot, List.of(signEntry(0, 0, "minecraft:overworld", "Town Hall")), GSON);
+
+        assertTrue(RegionShardedSignEntryLoader.hasSignData(storageRoot));
+    }
+
+    @Test
+    void loadSignEntriesRoundTripsAcrossRegionsAndDimensions(@TempDir Path storageRoot) {
+        var overworldEntry = signEntry(0, 0, "minecraft:overworld", "Town Hall");
+        var farOverworldEntry = signEntry(600, 600, "minecraft:overworld", "Outpost");
+        var netherEntry = signEntry(0, 0, "minecraft:the_nether", "Portal Hub");
+
+        RegionShardedSignEntryWriter.write(
+                storageRoot, List.of(overworldEntry, farOverworldEntry, netherEntry), GSON);
+
+        var loaded = RegionShardedSignEntryLoader.loadSignEntries(storageRoot, NO_GROUPS, GSON);
+
+        assertEquals(3, loaded.size());
+        assertTrue(loaded.contains(overworldEntry));
+        assertTrue(loaded.contains(farOverworldEntry));
+        assertTrue(loaded.contains(netherEntry));
+    }
+
+    private static SignEntry signEntry(int x, int z, String dimension, String label) {
+        return new SignEntry(
+                new SignEntryKey(x, 64, z, dimension),
+                "unknown",
+                new SignLinesParseResult("[poi]", label, label),
+                new SignLinesParseResult(null, "", ""));
+    }
+}

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryWriterTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryWriterTest.java
@@ -1,0 +1,78 @@
+package com.tpwalke2.bluemapsignmarkers.core.signs.persistence;
+
+import com.google.gson.Gson;
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignEntry;
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignEntryKey;
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignLinesParseResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RegionShardedSignEntryWriterTest {
+
+    private static final Gson GSON = new Gson();
+
+    @Test
+    void writesEachRegionToItsOwnFile(@TempDir Path storageRoot) throws IOException {
+        var overworldEntry = signEntry(0, 0, "minecraft:overworld", "Town Hall");
+        var netherEntry = signEntry(0, 0, "minecraft:the_nether", "Portal Hub");
+
+        RegionShardedSignEntryWriter.write(storageRoot, List.of(overworldEntry, netherEntry), GSON);
+
+        var overworldFile = storageRoot.resolve("minecraft").resolve("overworld").resolve("r.0.0.json");
+        var netherFile = storageRoot.resolve("minecraft").resolve("the_nether").resolve("r.0.0.json");
+        assertTrue(Files.exists(overworldFile));
+        assertTrue(Files.exists(netherFile));
+
+        var versionedFile = GSON.fromJson(Files.readString(overworldFile, StandardCharsets.UTF_8), VersionedSignFile.class);
+        assertEquals(SignFileVersions.V3, versionedFile.version());
+
+        var entries = GSON.fromJson(versionedFile.data(), SignEntry[].class);
+        assertEquals(1, entries.length);
+        assertEquals("Town Hall", entries[0].frontText().label());
+    }
+
+    @Test
+    void deletesStaleRegionFilesNotInCurrentSave(@TempDir Path storageRoot) throws IOException {
+        RegionShardedSignEntryWriter.write(
+                storageRoot, List.of(signEntry(0, 0, "minecraft:overworld", "Town Hall")), GSON);
+        var staleFile = storageRoot.resolve("minecraft").resolve("overworld").resolve("r.0.0.json");
+        assertTrue(Files.exists(staleFile));
+
+        // Re-save with that sign gone (e.g. removed) - the region file should disappear, not linger empty.
+        RegionShardedSignEntryWriter.write(storageRoot, List.of(), GSON);
+
+        assertFalse(Files.exists(staleFile));
+    }
+
+    @Test
+    void movingASignToAnotherRegionDropsTheOldRegionFile(@TempDir Path storageRoot) throws IOException {
+        RegionShardedSignEntryWriter.write(
+                storageRoot, List.of(signEntry(0, 0, "minecraft:overworld", "Town Hall")), GSON);
+
+        RegionShardedSignEntryWriter.write(
+                storageRoot, List.of(signEntry(600, 600, "minecraft:overworld", "Town Hall")), GSON);
+
+        var oldRegionFile = storageRoot.resolve("minecraft").resolve("overworld").resolve("r.0.0.json");
+        var newRegionFile = storageRoot.resolve("minecraft").resolve("overworld").resolve("r.1.1.json");
+        assertFalse(Files.exists(oldRegionFile));
+        assertTrue(Files.exists(newRegionFile));
+    }
+
+    private static SignEntry signEntry(int x, int z, String dimension, String label) {
+        return new SignEntry(
+                new SignEntryKey(x, 64, z, dimension),
+                "unknown",
+                new SignLinesParseResult("[poi]", label, label),
+                new SignLinesParseResult(null, "", ""));
+    }
+}

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryWriterTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/RegionShardedSignEntryWriterTest.java
@@ -42,20 +42,22 @@ class RegionShardedSignEntryWriterTest {
     }
 
     @Test
-    void deletesStaleRegionFilesNotInCurrentSave(@TempDir Path storageRoot) throws IOException {
+    void quarantinesStaleRegionFilesNotInCurrentSave(@TempDir Path storageRoot) throws IOException {
         RegionShardedSignEntryWriter.write(
                 storageRoot, List.of(signEntry(0, 0, "minecraft:overworld", "Town Hall")), GSON);
         var staleFile = storageRoot.resolve("minecraft").resolve("overworld").resolve("r.0.0.json");
         assertTrue(Files.exists(staleFile));
 
-        // Re-save with that sign gone (e.g. removed) - the region file should disappear, not linger empty.
+        // Re-save with that sign gone (e.g. removed) - the region file should move aside, not
+        // vanish outright: it may be gone because it was removed, or because it failed to load.
         RegionShardedSignEntryWriter.write(storageRoot, List.of(), GSON);
 
         assertFalse(Files.exists(staleFile));
+        assertTrue(Files.exists(staleFile.resolveSibling(staleFile.getFileName() + ".stale")));
     }
 
     @Test
-    void movingASignToAnotherRegionDropsTheOldRegionFile(@TempDir Path storageRoot) throws IOException {
+    void movingASignToAnotherRegionQuarantinesTheOldRegionFile(@TempDir Path storageRoot) throws IOException {
         RegionShardedSignEntryWriter.write(
                 storageRoot, List.of(signEntry(0, 0, "minecraft:overworld", "Town Hall")), GSON);
 
@@ -65,6 +67,7 @@ class RegionShardedSignEntryWriterTest {
         var oldRegionFile = storageRoot.resolve("minecraft").resolve("overworld").resolve("r.0.0.json");
         var newRegionFile = storageRoot.resolve("minecraft").resolve("overworld").resolve("r.1.1.json");
         assertFalse(Files.exists(oldRegionFile));
+        assertTrue(Files.exists(oldRegionFile.resolveSibling(oldRegionFile.getFileName() + ".stale")));
         assertTrue(Files.exists(newRegionFile));
     }
 

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignRegionKeyTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignRegionKeyTest.java
@@ -1,0 +1,59 @@
+package com.tpwalke2.bluemapsignmarkers.core.signs.persistence;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SignRegionKeyTest {
+
+    @Test
+    void forPositionAssignsRegionZeroAtOrigin() {
+        var key = SignRegionKey.forPosition("minecraft:overworld", 0, 0);
+
+        assertEquals(new SignRegionKey("minecraft:overworld", 0, 0), key);
+    }
+
+    @Test
+    void forPositionUsesFloorDivisionForNegativeCoordinates() {
+        var negative = SignRegionKey.forPosition("minecraft:overworld", -1, -1);
+
+        // Truncating division would put x=-1 in the same region as x=0 (both round toward zero); floorDiv
+        // correctly puts it in the region to the west/north instead.
+        assertEquals(-1, negative.regionX());
+        assertEquals(-1, negative.regionZ());
+    }
+
+    @Test
+    void forPositionSplitsAtRegionBoundary() {
+        var lastBlockOfRegionZero = SignRegionKey.forPosition("minecraft:overworld", 511, 511);
+        var firstBlockOfRegionOne = SignRegionKey.forPosition("minecraft:overworld", 512, 512);
+
+        assertEquals(0, lastBlockOfRegionZero.regionX());
+        assertEquals(0, lastBlockOfRegionZero.regionZ());
+        assertEquals(1, firstBlockOfRegionOne.regionX());
+        assertEquals(1, firstBlockOfRegionOne.regionZ());
+    }
+
+    @Test
+    void relativeFilePathSplitsNamespaceAndPath() {
+        var key = new SignRegionKey("minecraft:the_nether", 2, -3);
+
+        assertEquals(Path.of("minecraft", "the_nether", "r.2.-3.json"), key.relativeFilePath());
+    }
+
+    @Test
+    void relativeFilePathHandlesDimensionWithoutColon() {
+        var key = new SignRegionKey("unknown", 0, 0);
+
+        assertEquals(Path.of("unknown", "r.0.0.json"), key.relativeFilePath());
+    }
+
+    @Test
+    void relativeFilePathHandlesNestedDimensionPath() {
+        var key = new SignRegionKey("somemod:custom/dimension", 0, 0);
+
+        assertEquals(Path.of("somemod", "custom", "dimension", "r.0.0.json"), key.relativeFilePath());
+    }
+}

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignRegionPartitionerTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/SignRegionPartitionerTest.java
@@ -1,0 +1,55 @@
+package com.tpwalke2.bluemapsignmarkers.core.signs.persistence;
+
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignEntry;
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignEntryKey;
+import com.tpwalke2.bluemapsignmarkers.core.signs.SignLinesParseResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SignRegionPartitionerTest {
+
+    @Test
+    void groupsEntriesByRegionAndDimension() {
+        var overworldEntry = signEntry(0, 0, "minecraft:overworld");
+        var netherEntry = signEntry(0, 0, "minecraft:the_nether");
+        var farOverworldEntry = signEntry(600, 600, "minecraft:overworld");
+
+        var partitions = SignRegionPartitioner.partition(List.of(overworldEntry, netherEntry, farOverworldEntry));
+
+        assertEquals(3, partitions.size());
+        assertTrue(partitions.get(new SignRegionKey("minecraft:overworld", 0, 0)).contains(overworldEntry));
+        assertTrue(partitions.get(new SignRegionKey("minecraft:the_nether", 0, 0)).contains(netherEntry));
+        assertTrue(partitions.get(new SignRegionKey("minecraft:overworld", 1, 1)).contains(farOverworldEntry));
+    }
+
+    @Test
+    void groupsMultipleEntriesInSameRegionTogether() {
+        var first = signEntry(1, 1, "minecraft:overworld");
+        var second = signEntry(2, 2, "minecraft:overworld");
+
+        var partitions = SignRegionPartitioner.partition(List.of(first, second));
+
+        assertEquals(1, partitions.size());
+        var region = partitions.get(new SignRegionKey("minecraft:overworld", 0, 0));
+        assertEquals(2, region.size());
+    }
+
+    @Test
+    void emptyInputProducesNoPartitions() {
+        var partitions = SignRegionPartitioner.partition(List.of());
+
+        assertEquals(0, partitions.size());
+    }
+
+    private static SignEntry signEntry(int x, int z, String dimension) {
+        return new SignEntry(
+                new SignEntryKey(x, 64, z, dimension),
+                "unknown",
+                new SignLinesParseResult("[poi]", "label", "detail"),
+                new SignLinesParseResult(null, "", ""));
+    }
+}


### PR DESCRIPTION
Region-shards sign persistence into per-(dimension, region) JSON files stored under a per-server root, replacing the single flat signs.json per world, and fixes a related storage-path bug (#133) along the way.

## Why

Chunk deletion/regen tools (Chunky, MCA Selector, manual .mca deletion) give no "sign removed" event, so stale signs accumulate forever; fixing that requires cheaply answering "what signs exist in this region," which a single-file, full-scan load can't do.
Region-sharded storage (32×32 chunks, matching Minecraft's own Anvil region size) gives that query a natural home — the actual reconciliation logic is a follow-up issue (#110).

Addresses GitHub issues
- #109
- #133
- #136

## Changes

- Storage layout: signs now live at {server_root}/bluemapsignmarkers/{level}/{namespace}/{path}/r.{regionX}.{regionZ}.json instead of config/bluemapsignmarkers/{level}/signs.json — new SignRegionKey/SignRegionPartitioner do the region-coordinate math (floorDiv-based,
so negative coordinates partition correctly) and dimension-string splitting.
- ServerPathProvider: repurposed from a dead/unimplemented interface into getMarkerStorageRoot(MinecraftServer), implemented on BlueMapSignMarkersMod. Requires .normalize() on the resolved level path — LevelResource.ROOT's relative path is literally ".", and without
normalizing, getParent()/getFileName() land one level too deep (inside the world save folder instead of beside it).
- Read/write: RegionShardedSignEntryLoader (walk + load all region files) and RegionShardedSignEntryWriter (partition + write per-region files, deleting stale empty-region files) replace the single-file logic in SignProvider.
- Migration: LegacySignFileMigrator one-shot migrates an existing flat signs.json (reusing the existing V1→V2→V3 loader chain unchanged) into region-sharded files, then backs up the legacy file (.migrated suffix, via new FileUtils.moveToBackup) rather than deleting it.  Migration locates the legacy file via the old (unchanged) path formula, since that's what's actually on disk for existing installs.
- mod_version bumped 26.2-0.16.1 → 26.2-0.17.0 (storage location change for every install).
- New tests for region-key math, dimension splitting, partitioning, round-trip load/write, and migration.
- Design rationale and rejected alternatives (SQLite, H2, LMDB/MapDB, store-by-player) documented in plans/region-sharded-sign-persistence-plan.md.

## Testing

- ./gradlew test — new persistence/migration/region-math tests pass alongside existing suite.
- ./gradlew build — full build succeeds.
- Manual via ./gradlew runServer: place signs across multiple regions and dimensions (overworld + nether), restart, confirm markers still appear; separately, boot against a pre-existing flat signs.json fixture and confirm it migrates to the new region-file layout with
the legacy file backed up, not deleted.