### PR TITLE
#121 allow hot reloads on config

### DIFF
--- a/plans/marker-group-config-reload-plan.md
+++ b/plans/marker-group-config-reload-plan.md
@@ -1,0 +1,201 @@
+# Marker group config reload on `/bluemap reload`
+
+## Context
+
+Today, per `agent-context/context/config-and-persistence.md`: "Config is not hot-reloadable — a config file edit
+requires a server restart." Three independent snapshots of marker-group config are taken once and never refreshed:
+
+1. `ConfigManager.coreConfig` (`config/ConfigManager.java:10`) — `static final`, loaded once at class-init.
+2. `SignHelper.signLinesParser` (`core/signs/SignHelper.java:15`) — `static final`, built once from
+   `ConfigManager.get().getMarkerGroups()` at class-init. Used to parse sign text into `SignLinesParseResult`
+   whenever a `SignEntry` is built (player edit, block-entity load).
+3. `SignManager.prefixGroupMap` (`core/signs/SignManager.java:64,67-76`) — built once in the singleton constructor,
+   plus one `MarkerSetIdentifierCollection`/`ActionFactory` pair built alongside it. Used to resolve a cached sign's
+   prefix to its current `MarkerGroup` (icon, name, offsets, visibility, distances) on every add/update/remove
+   dispatch.
+
+`SignManager` already implements `IResetHandler.reset()` → `reloadSigns()`, fired from
+`BlueMapAPIConnector.onEnable` whenever `markerActionQueue.isShutdown()` is true — i.e. after a prior `onDisable`.
+Per `core-pipeline.md:140-144`, this is "why a BlueMap reload replays the entire sign cache rather than assuming
+stale `MarkerSet` state is still valid" — the mod already treats an `onDisable`→`onEnable` cycle as BlueMap's
+`/bluemap reload` signal. `onEnable` itself needs no change: it already fires `reset()` unconditionally through the
+`IResetHandler` abstraction on every such cycle; the extension point is what `reset()` *does*, not `onEnable`.
+
+`reloadSigns()` clears `signCache`/`chunkIndex` before replaying, so every cached sign takes the **Add** branch of
+`addOrUpdateSign`'s decision table on replay (`existing` is always `null` post-clear) — it re-dispatches
+`AddMarkerAction` for everything, and `BlueMapAPIConnector.addMarker` does a `Map.put` keyed by position, so a
+replayed "add" overwrites whatever marker was already there. This means replay *already* has the right shape to
+pick up changed icon/offset/distance/visibility values for existing signs — the only reason it doesn't today is
+that `prefixGroupMap` (and the parser, and the identifier cache) are frozen at construction time. Fixing that
+staleness is the entire scope of this change.
+
+## Goal
+
+Satisfy: *as a server operator, when I edit `BMSM-Core.json` and run `/bluemap reload`, markers reflect the new
+group definitions (icon, name, offsets, visibility, distances, matchType, prefix) without a server restart.*
+
+## Design
+
+### `ConfigManager` — make the singleton reloadable
+
+```java
+private static volatile BMSMConfigV2 coreConfig = loadCoreConfig();
+
+public static BMSMConfigV2 get() { return coreConfig; }
+
+public static synchronized void reload() {
+    coreConfig = loadCoreConfig();
+}
+```
+
+`loadCoreConfig()` is unchanged — it already re-reads from disk via `ConfigProvider.loadConfig()` and falls back to
+defaults on failure, so `reload()` is just "run that again and swap the reference." `volatile` is enough for safe
+publication (the new `BMSMConfigV2` is fully constructed before the reference is swapped); no reader needs a lock.
+
+### `SignHelper` — rebuild the cached parser
+
+```java
+private static volatile SignLinesParser signLinesParser = buildParser();
+
+private static SignLinesParser buildParser() {
+    return new SignLinesParser(Arrays.asList(ConfigManager.get().getMarkerGroups()));
+}
+
+public static void reloadParser() {
+    signLinesParser = buildParser();
+}
+```
+
+Needed so any sign parsed *after* the reload (a player edit, or a chunk loading in) uses the new prefixes/matchType,
+not stale ones — without this, a config edit that changes `matchType` or `prefix` would parse newly-touched signs
+inconsistently with what `SignManager.prefixGroupMap` now expects.
+
+### `SignManager` — rebuild `prefixGroupMap`, `ActionFactory`, `MarkerSetIdentifierCollection` on reset
+
+Extract the constructor's group-map-building loop into a private method, reuse it from both the constructor and a
+new `reloadConfig()`:
+
+```java
+private volatile Map<String, MarkerGroup> prefixGroupMap;
+private volatile ActionFactory actionFactory;
+
+private SignManager() {
+    prefixGroupMap = buildPrefixGroupMap();
+    actionFactory = new ActionFactory(new MarkerSetIdentifierCollection());
+    blueMapAPIConnector = new BlueMapAPIConnector();
+    blueMapAPIConnector.addResetHandler(this);
+}
+
+private static Map<String, MarkerGroup> buildPrefixGroupMap() {
+    var groups = ConfigManager.get().getMarkerGroups();
+    Map<String, MarkerGroup> result = new TreeMap<>();
+    for (var group : groups) {
+        if (result.containsKey(group.prefix())) {
+            LOGGER.warn("Duplicate marker group prefix found: {}", group.prefix());
+            continue;
+        }
+        result.put(group.prefix(), group);
+    }
+    return result;
+}
+
+@Override
+public void reset() {
+    reloadConfig();
+    reloadSigns();
+}
+
+private void reloadConfig() {
+    LOGGER.info("Reloading marker group configuration...");
+    ConfigManager.reload();
+    SignHelper.reloadParser();
+    prefixGroupMap = buildPrefixGroupMap();
+    actionFactory = new ActionFactory(new MarkerSetIdentifierCollection());
+}
+```
+
+`reloadConfig()` runs before `reloadSigns()` so the replay dispatches with the fresh group values.
+
+Rebuilding `actionFactory`/`MarkerSetIdentifierCollection` (rather than reusing the existing one) closes the "cache-key
+growth risk" flagged in `plans/codebase-review-2026-07-11.md:248-250`: `MarkerSetIdentifier`/`markerSetsCache` key on
+the *entire* `MarkerGroup` record by value, so a changed icon/offset/distance produces a new, never-evicted entry in
+a long-lived cache — starting a fresh `MarkerSetIdentifierCollection` on every reload means it never accumulates
+entries for group values from before the last reload. This pairs with `BlueMapAPIConnector.resetQueue()`, which
+already gives `markerSetsCache` a clean slate on every reload — now both identifier caches reset together.
+
+`prefixGroupMap`/`actionFactory` change from `final` to `volatile` fields — reassigned wholesale (never mutated in
+place), so `volatile` alone gives readers on other threads (mixins, `ReactiveQueue` worker threads) a consistent,
+fully-built reference without needing a lock.
+
+### `SignEntryHelper.isMarkerType` — guard against a prefix no longer configured
+
+```java
+public static boolean isMarkerType(SignEntry signEntry, Map<String, MarkerGroup> prefixGroupMap, MarkerGroupType markerGroupType) {
+    var prefix = getPrefix(signEntry);
+    if (prefix == null) return false;
+    var group = prefixGroupMap.get(prefix);
+    return group != null && group.type() == markerGroupType;
+}
+```
+
+Today `prefixGroupMap` is only ever built from the same config a cached sign was parsed against, so `getPrefix`
+always resolves — `prefixGroupMap.get(prefix)` can never be `null`, and the direct `.type()` call is safe. Once
+config is reloadable, an operator can rename or delete a group's prefix entirely, and existing cached signs still
+carry the *old* prefix string — this NPEs today without the guard. Unit-testable (`SignEntryHelper` is plain Java,
+already covered per `testing.md`); add a case to a new `SignEntryHelperTest` (see Tests below).
+
+## Known limitation (not fixed here)
+
+If a group's **`name`** changes (the field BlueMap uses as the `MarkerSet`/layer label,
+`BlueMapAPIConnector.getMarkerSets:190-200`) while its `prefix` stays the same, replay adds the marker into a
+*new*-named `MarkerSet` but nothing removes it from the old-named one (nothing in `SignManager` remembers which
+`MarkerGroup` a cached sign was last dispatched under, only its prefix string) — the marker briefly appears under
+both the old and new set names until the old one is manually removed in BlueMap's web UI, or the sign is edited or
+the server restarted. Fixing this correctly means tracking, per cached sign, the last-dispatched `MarkerGroup`
+value (not just its prefix) — a larger change than "pick up config edits on reload" calls for. Renaming a group's
+`prefix` (what text must appear on the sign) already goes through the pre-existing remove-then-add path
+(`addOrUpdateSign`'s prefix-changed branch) *only when a player re-edits that specific sign* — reload's clear-and-replay
+doesn't hit that branch (every replayed entry looks "new" against the just-cleared cache), so a prefix rename alone,
+with no in-game re-edit, also leaves the marker under its old prefix's group semantics until the operator edits or
+removes the physical sign. Both are edge cases outside "change icon/offset/visibility/distances and see it reflected
+on reload," the case this plan targets.
+
+## Out of scope
+
+- Fixing `SignManager`'s non-`volatile` singleton `instance` field (double-checked locking bug flagged separately in
+  `plans/codebase-review-2026-07-11.md`) — pre-existing, unrelated to config reload.
+- A config file watcher / auto-reload without `/bluemap reload` — not requested; this rides the existing
+  `IResetHandler` reset signal, the only reload trigger the mod has.
+- Fully resolving the group-rename duplicate-marker-set edge case above.
+
+## Changes (files)
+
+1. **`config/ConfigManager.java`** — `coreConfig` field → `volatile`, add `public static synchronized void reload()`.
+2. **`core/signs/SignHelper.java`** — `signLinesParser` field → `volatile`, extract `buildParser()`, add
+   `public static void reloadParser()`.
+3. **`core/signs/SignManager.java`** — extract `buildPrefixGroupMap()` (static), `prefixGroupMap`/`actionFactory`
+   fields → `volatile` (drop `final`), add `reloadConfig()`, call it from `reset()` before `reloadSigns()`.
+4. **`core/signs/SignEntryHelper.java`** — null-guard `isMarkerType` against an unrecognized prefix.
+5. **New test** `src/test/java/.../core/signs/SignEntryHelperTest.java` — covers `getPrefix`/`isMarkerType`/
+   `getLabel`/`getDetail` (currently untested per `testing.md:68`), including the new case: a prefix not present in
+   `prefixGroupMap` returns `false` from `isMarkerType` rather than throwing.
+
+No `mod_version`/`SignFileVersions` bump — no persisted-format change, this is runtime-cache-only.
+
+## Verification
+
+- `./gradlew test` — new `SignEntryHelperTest` passes alongside the existing suite.
+- `./gradlew build` — full build still succeeds.
+- Manual, via `./gradlew runServer` with BlueMap loaded (`ConfigManager`/`SignManager`/`SignHelper`/
+  `BlueMapAPIConnector` are game/API-coupled, no automated coverage possible per `testing.md`):
+  1. Place a `[poi]` sign, confirm its marker appears with the default icon/offset. Edit `BMSM-Core.json`'s `[poi]`
+     group: change `icon`, `offsetX`/`offsetY`, `defaultHidden`, `minDistance`/`maxDistance`. Run `/bluemap reload`.
+     Confirm the marker updates in place (icon/position-offset/visibility/distance-culling) with no server restart
+     and no duplicate marker appears.
+  2. Add a second marker group to the config with a new prefix, run `/bluemap reload`, place a sign using the new
+     prefix, confirm it's recognized without a restart (proves `SignHelper`'s parser picked up the new group).
+  3. Remove a marker group's prefix entirely from config (with an existing sign still using it), run
+     `/bluemap reload`, confirm no exception/crash in the server log (the `isMarkerType` null-guard) — the sign's
+     marker is expected to remain in BlueMap until the sign itself is edited/removed (documented limitation above).
+  4. Rename a group's `name` field only, run `/bluemap reload`, confirm the marker appears under the new set name
+     (and note, per the documented limitation, whether it also still appears under the old set name).

--- a/plans/marker-group-reload-followups-todo.md
+++ b/plans/marker-group-reload-followups-todo.md
@@ -1,0 +1,46 @@
+# Marker group reload — follow-up todo list
+
+Deferred edge cases from `plans/marker-group-config-reload-plan.md`, not tracked anywhere else (checked
+`plans/codebase-review-2026-07-11.md` and the rest of `plans/` — no match). Neither blocks that plan's core
+goal (icon/offset/visibility/distance edits reflected on `/bluemap reload`); both need `SignManager` to track,
+per cached sign, the last-dispatched `MarkerGroup` value (not just its prefix string) to fix properly.
+
+## 1. Group rename leaves a duplicate marker in the old-named `MarkerSet`
+
+Renaming a group's `name` field (BlueMap's `MarkerSet`/layer label) while its `prefix` stays the same: reload
+resolves the new `MarkerGroup` value (different `name`), so `BlueMapAPIConnector.getMarkerSets` looks it up by the
+*new* name, misses, and creates/reuses a `MarkerSet` under that new name — but nothing ever removes the marker from
+the *old*-named set, because `SignManager` only remembers a cached sign's prefix string, not the full `MarkerGroup`
+(specifically its `name`) it was last dispatched under. Result: the marker shows up under both set names.
+
+No operator-facing remediation exists today: BlueMap's web UI has no marker/marker-set edit or delete capability,
+and it's unconfirmed whether a plain server restart would even clear it (BlueMap persists marker-set state itself,
+independent of this mod's in-memory cache) — removing the stale entry likely requires a mod code fix, not a
+workaround.
+
+**Fix sketch for a future plan:** give `SignManager` a way to know the previous `MarkerGroup` (not just prefix) each
+cached sign was last dispatched under — e.g. a side map `Map<SignEntryKey, MarkerGroup>` updated on every dispatch,
+or store the resolved `MarkerGroup` alongside `SignEntry` in `signCache`. In `reloadConfig()`/`reloadSigns()`,
+compare old vs. newly-resolved group per entry; if `name()` differs, dispatch an explicit `RemoveMarkerAction`
+against the *old* `MarkerSetIdentifier` (mirroring `addOrUpdateSign`'s existing prefix-changed remove-then-add
+branch) before the replay's `AddMarkerAction` under the new one. Note this only empties the old `MarkerSet`'s marker
+list — it doesn't remove the (now-empty) `MarkerSet` itself from `blueMapMap.getMarkerSets()`, which would still
+show up as an empty, togglable layer in BlueMap's UI unless explicitly deleted once no sign references it anymore.
+
+## 2. Prefix rename without an in-game sign edit doesn't reclassify the sign
+
+`SignEntry` stores only the *parsed* result (`SignLinesParseResult`: prefix/label/detail) — never the raw sign
+text — so re-parsing against an updated config isn't possible from the cache alone. The existing remove-then-add
+path for a prefix change (`SignManager.addOrUpdateSign`'s prefix-changed branch) only ever runs when a player
+re-edits that specific sign in-game (which re-parses live text via `SignHelper.createSignEntry`) or a chunk reloads
+it (`BLOCK_ENTITY_LOAD`, same re-parse). Reload's clear-and-replay never re-parses — it just re-dispatches each
+cached entry's already-resolved prefix — so renaming a group's `prefix` in `BMSM-Core.json`, with no matching
+in-game re-edit or chunk reload of that sign, leaves the marker classified under the old prefix's group semantics
+indefinitely (or, if the old prefix was removed rather than renamed, silently orphaned per
+`marker-group-config-reload-plan.md`'s `isMarkerType` null-guard behavior).
+
+**Fix sketch for a future plan:** either (a) store the raw front/back sign text alongside the parsed result in
+`SignEntry` (and in persisted `signs.json` — a `SignFileVersions` bump) so `reloadSigns()` can re-run
+`SignLinesParser` against current config for every cached entry before re-dispatching, or (b) on reload, re-read
+each cached sign's live `SignBlockEntity` text directly from its `ServerLevel` (heavier: requires the chunk to be
+loaded, and a lookup from `SignEntryKey` back to a world/`BlockPos`, not something `SignManager` has today).

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/config/ConfigManager.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/config/ConfigManager.java
@@ -7,13 +7,17 @@ import org.slf4j.LoggerFactory;
 
 public class ConfigManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(Constants.MOD_ID);
-    private static final BMSMConfigV2 coreConfig = loadCoreConfig();
+    private static volatile BMSMConfigV2 coreConfig = loadCoreConfig();
 
     private ConfigManager() {
     }
 
     public static BMSMConfigV2 get() {
         return coreConfig;
+    }
+
+    public static synchronized void reload() {
+        coreConfig = loadCoreConfig();
     }
 
     private static synchronized BMSMConfigV2 loadCoreConfig() {

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
@@ -158,13 +158,14 @@ public class BlueMapAPIConnector {
     }
 
     private void onEnable(BlueMapAPI api) {
+        this.blueMapAPI = api;
+
         if (markerActionQueue.isShutdown()) {
             resetQueue();
 
             fireReset();
         }
 
-        this.blueMapAPI = api;
         markerActionQueue.process();
     }
 

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignEntryHelper.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignEntryHelper.java
@@ -18,7 +18,9 @@ public class SignEntryHelper {
             Map<String, MarkerGroup> prefixGroupMap,
             MarkerGroupType markerGroupType) {
         var prefix = getPrefix(signEntry);
-        return prefix != null && prefixGroupMap.get(prefix).type() == markerGroupType;
+        if (prefix == null) return false;
+        var group = prefixGroupMap.get(prefix);
+        return group != null && group.type() == markerGroupType;
     }
 
     public static String getLabel(SignEntry signEntry) {

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignHelper.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignHelper.java
@@ -12,7 +12,15 @@ public class SignHelper {
     private SignHelper() {
     }
 
-    private static final SignLinesParser signLinesParser = new SignLinesParser(Arrays.asList(ConfigManager.get().getMarkerGroups()));
+    private static volatile SignLinesParser signLinesParser = buildParser();
+
+    private static SignLinesParser buildParser() {
+        return new SignLinesParser(Arrays.asList(ConfigManager.get().getMarkerGroups()));
+    }
+
+    public static void reloadParser() {
+        signLinesParser = buildParser();
+    }
 
     public static SignEntry createSignEntry(
             SignBlockEntity signBlockEntity,

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignManager.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignManager.java
@@ -57,17 +57,22 @@ public class SignManager implements IResetHandler {
         return getInstance().chunkIndex.keysInChunk(parentMap, chunkX, chunkZ);
     }
 
+    private record RuntimeConfig(Map<String, MarkerGroup> prefixGroupMap, ActionFactory actionFactory) {
+    }
+
     private final BlueMapAPIConnector blueMapAPIConnector;
-    private volatile ActionFactory actionFactory;
     private final ConcurrentMap<SignEntryKey, SignEntry> signCache = new ConcurrentHashMap<>();
     private final SignChunkIndex chunkIndex = new SignChunkIndex();
-    private volatile Map<String, MarkerGroup> prefixGroupMap;
+    private volatile RuntimeConfig runtimeConfig;
 
     private SignManager() {
-        prefixGroupMap = buildPrefixGroupMap();
-        actionFactory = new ActionFactory(new MarkerSetIdentifierCollection());
+        runtimeConfig = buildRuntimeConfig();
         blueMapAPIConnector = new BlueMapAPIConnector();
         blueMapAPIConnector.addResetHandler(this);
+    }
+
+    private static RuntimeConfig buildRuntimeConfig() {
+        return new RuntimeConfig(buildPrefixGroupMap(), new ActionFactory(new MarkerSetIdentifierCollection()));
     }
 
     private static Map<String, MarkerGroup> buildPrefixGroupMap() {
@@ -103,6 +108,10 @@ public class SignManager implements IResetHandler {
     }
 
     private void addOrUpdateSign(SignEntry signEntry) {
+        var config = runtimeConfig;
+        var prefixGroupMap = config.prefixGroupMap();
+        var actionFactory = config.actionFactory();
+
         var key = signEntry.key();
         var existing = signCache.get(key);
 
@@ -117,6 +126,12 @@ public class SignManager implements IResetHandler {
         }
 
         if (shouldAddPOIMarker(existing, isPOIMarker)) {
+            var newGroup = prefixGroupMap.get(newPrefix);
+            if (newGroup == null) {
+                LOGGER.warn("No marker group configured for prefix {}, skipping add: {}", newPrefix, signEntry);
+                return;
+            }
+
             LOGGER.debug("Adding POI marker: {}", signEntry);
             signCache.put(key, signEntry);
             chunkIndex.add(key);
@@ -128,7 +143,7 @@ public class SignManager implements IResetHandler {
                             key.parentMap(),
                             label,
                             detail,
-                            prefixGroupMap.get(newPrefix)));
+                            newGroup));
             return;
         }
 
@@ -156,35 +171,50 @@ public class SignManager implements IResetHandler {
                 var existingDetail = SignEntryHelper.getDetail(existing);
 
                 if (isTextDifferent(existingLabel, label, existingDetail, detail)) {
-                    LOGGER.debug("Updating POI marker label and detail");
+                    var group = prefixGroupMap.get(newPrefix);
+                    if (group == null) {
+                        LOGGER.warn("No marker group configured for prefix {}, skipping update: {}", newPrefix, signEntry);
+                    } else {
+                        LOGGER.debug("Updating POI marker label and detail");
+                        blueMapAPIConnector.dispatch(
+                                actionFactory.createUpdatePOIAction(
+                                        key.x(),
+                                        key.y(),
+                                        key.z(),
+                                        key.parentMap(),
+                                        label,
+                                        detail,
+                                        group));
+                    }
+                }
+            } else {
+                var existingGroup = prefixGroupMap.get(existingPrefix);
+                if (existingGroup == null) {
+                    LOGGER.warn("No marker group configured for previous prefix {}, skipping remove: {}", existingPrefix, signEntry);
+                } else {
                     blueMapAPIConnector.dispatch(
-                            actionFactory.createUpdatePOIAction(
+                            actionFactory.createRemovePOIAction(
+                                    key.x(),
+                                    key.y(),
+                                    key.z(),
+                                    key.parentMap(),
+                                    existingGroup));
+                }
+
+                var newGroup = prefixGroupMap.get(newPrefix);
+                if (newGroup == null) {
+                    LOGGER.warn("No marker group configured for prefix {}, skipping add: {}", newPrefix, signEntry);
+                } else {
+                    blueMapAPIConnector.dispatch(
+                            actionFactory.createAddPOIAction(
                                     key.x(),
                                     key.y(),
                                     key.z(),
                                     key.parentMap(),
                                     label,
                                     detail,
-                                    prefixGroupMap.get(newPrefix)));
+                                    newGroup));
                 }
-            } else {
-                blueMapAPIConnector.dispatch(
-                        actionFactory.createRemovePOIAction(
-                                key.x(),
-                                key.y(),
-                                key.z(),
-                                key.parentMap(),
-                                prefixGroupMap.get(existingPrefix)));
-
-                blueMapAPIConnector.dispatch(
-                        actionFactory.createAddPOIAction(
-                                key.x(),
-                                key.y(),
-                                key.z(),
-                                key.parentMap(),
-                                label,
-                                detail,
-                                prefixGroupMap.get(newPrefix)));
             }
         }
     }
@@ -222,13 +252,21 @@ public class SignManager implements IResetHandler {
             return;
         }
 
+        var config = runtimeConfig;
+        var group = config.prefixGroupMap().get(prefix);
+
+        if (group == null) {
+            LOGGER.warn("No marker group configured for prefix {}, skipping remove dispatch: {}", prefix, removed);
+            return;
+        }
+
         blueMapAPIConnector.dispatch(
-                actionFactory.createRemovePOIAction(
+                config.actionFactory().createRemovePOIAction(
                         key.x(),
                         key.y(),
                         key.z(),
                         key.parentMap(),
-                        prefixGroupMap.get(prefix)));
+                        group));
     }
 
     private void removeEntry(SignEntry signEntry) {
@@ -245,7 +283,6 @@ public class SignManager implements IResetHandler {
         LOGGER.info("Reloading marker group configuration...");
         ConfigManager.reload();
         SignHelper.reloadParser();
-        prefixGroupMap = buildPrefixGroupMap();
-        actionFactory = new ActionFactory(new MarkerSetIdentifierCollection());
+        runtimeConfig = buildRuntimeConfig();
     }
 }

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignManager.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignManager.java
@@ -58,27 +58,30 @@ public class SignManager implements IResetHandler {
     }
 
     private final BlueMapAPIConnector blueMapAPIConnector;
-    private final ActionFactory actionFactory;
+    private volatile ActionFactory actionFactory;
     private final ConcurrentMap<SignEntryKey, SignEntry> signCache = new ConcurrentHashMap<>();
     private final SignChunkIndex chunkIndex = new SignChunkIndex();
-    private final Map<String, MarkerGroup> prefixGroupMap;
+    private volatile Map<String, MarkerGroup> prefixGroupMap;
 
     private SignManager() {
+        prefixGroupMap = buildPrefixGroupMap();
+        actionFactory = new ActionFactory(new MarkerSetIdentifierCollection());
+        blueMapAPIConnector = new BlueMapAPIConnector();
+        blueMapAPIConnector.addResetHandler(this);
+    }
+
+    private static Map<String, MarkerGroup> buildPrefixGroupMap() {
         var groups = ConfigManager.get().getMarkerGroups();
-        prefixGroupMap = new TreeMap<>();
+        Map<String, MarkerGroup> result = new TreeMap<>();
         for (var group : groups) {
-            if (prefixGroupMap.containsKey(group.prefix())) {
+            if (result.containsKey(group.prefix())) {
                 LOGGER.warn("Duplicate marker group prefix found: {}", group.prefix());
                 continue;
             }
 
-            prefixGroupMap.put(group.prefix(), group);
+            result.put(group.prefix(), group);
         }
-
-        MarkerSetIdentifierCollection markerSetIdentifierCollection = new MarkerSetIdentifierCollection();
-        actionFactory = new ActionFactory(markerSetIdentifierCollection);
-        blueMapAPIConnector = new BlueMapAPIConnector();
-        blueMapAPIConnector.addResetHandler(this);
+        return result;
     }
 
     private List<SignEntry> getAllSigns() {
@@ -234,6 +237,15 @@ public class SignManager implements IResetHandler {
 
     @Override
     public void reset() {
+        reloadConfig();
         reloadSigns();
+    }
+
+    private void reloadConfig() {
+        LOGGER.info("Reloading marker group configuration...");
+        ConfigManager.reload();
+        SignHelper.reloadParser();
+        prefixGroupMap = buildPrefixGroupMap();
+        actionFactory = new ActionFactory(new MarkerSetIdentifierCollection());
     }
 }

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignManager.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignManager.java
@@ -121,7 +121,12 @@ public class SignManager implements IResetHandler {
         var newPrefix = SignEntryHelper.getPrefix(signEntry);
 
         if (newPrefix == null) {
-            LOGGER.debug("Cannot add or update sign as no prefix found: {}", signEntry);
+            if (existing != null) {
+                LOGGER.debug("Removing POI marker as sign no longer has a prefix: {}", signEntry);
+                removeEntry(signEntry);
+            } else {
+                LOGGER.debug("Cannot add or update sign as no prefix found: {}", signEntry);
+            }
             return;
         }
 

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignEntryHelperTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignEntryHelperTest.java
@@ -1,0 +1,123 @@
+package com.tpwalke2.bluemapsignmarkers.core.signs;
+
+import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroup;
+import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupMatchType;
+import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SignEntryHelperTest {
+
+    private static final SignEntryKey KEY = new SignEntryKey(1, 2, 3, "minecraft:overworld");
+
+    private static MarkerGroup poiGroup(String prefix) {
+        return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, "Points of Interest", null, 0, 0, false, 0.0, 10000000.0);
+    }
+
+    private static SignEntry signEntry(SignLinesParseResult frontText, SignLinesParseResult backText) {
+        return new SignEntry(KEY, "unknown", frontText, backText);
+    }
+
+    private static SignLinesParseResult parsed(String prefix, String label, String detail) {
+        return new SignLinesParseResult(prefix, label, detail);
+    }
+
+    private static SignLinesParseResult empty() {
+        return new SignLinesParseResult(null, "", "");
+    }
+
+    @Test
+    void getPrefixPrefersFrontText() {
+        var entry = signEntry(parsed("[poi]", "Town Hall", "Town Hall"), parsed("[event]", "Fair", "Fair"));
+
+        assertEquals("[poi]", SignEntryHelper.getPrefix(entry));
+    }
+
+    @Test
+    void getPrefixFallsBackToBackText() {
+        var entry = signEntry(empty(), parsed("[event]", "Fair", "Fair"));
+
+        assertEquals("[event]", SignEntryHelper.getPrefix(entry));
+    }
+
+    @Test
+    void getPrefixReturnsNullWhenNeitherSideMatches() {
+        var entry = signEntry(empty(), empty());
+
+        assertNull(SignEntryHelper.getPrefix(entry));
+    }
+
+    @Test
+    void isMarkerTypeTrueWhenPrefixResolvesToMatchingType() {
+        var entry = signEntry(parsed("[poi]", "Town Hall", "Town Hall"), empty());
+        var prefixGroupMap = Map.of("[poi]", poiGroup("[poi]"));
+
+        assertTrue(SignEntryHelper.isMarkerType(entry, prefixGroupMap, MarkerGroupType.POI));
+    }
+
+    @Test
+    void isMarkerTypeFalseWhenNoPrefix() {
+        var entry = signEntry(empty(), empty());
+        var prefixGroupMap = Map.of("[poi]", poiGroup("[poi]"));
+
+        assertFalse(SignEntryHelper.isMarkerType(entry, prefixGroupMap, MarkerGroupType.POI));
+    }
+
+    @Test
+    void isMarkerTypeFalseWhenPrefixNoLongerConfigured() {
+        // Simulates a cached sign whose prefix was removed/renamed out of the config on reload -
+        // prefixGroupMap.get(prefix) is null, and isMarkerType must not throw.
+        var entry = signEntry(parsed("[poi]", "Town Hall", "Town Hall"), empty());
+        var prefixGroupMap = Map.<String, MarkerGroup>of();
+
+        assertFalse(SignEntryHelper.isMarkerType(entry, prefixGroupMap, MarkerGroupType.POI));
+    }
+
+    @Test
+    void getLabelPrefersFrontText() {
+        var entry = signEntry(parsed("[poi]", "Town Hall", "Town Hall"), parsed("[poi]", "Back Label", "Back Label"));
+
+        assertEquals("Town Hall", SignEntryHelper.getLabel(entry));
+    }
+
+    @Test
+    void getLabelFallsBackToBackTextWhenFrontBlank() {
+        var entry = signEntry(empty(), parsed("[poi]", "Back Label", "Back Label"));
+
+        assertEquals("Back Label", SignEntryHelper.getLabel(entry));
+    }
+
+    @Test
+    void getLabelReturnsEmptyWhenBothBlank() {
+        var entry = signEntry(empty(), empty());
+
+        assertEquals("", SignEntryHelper.getLabel(entry));
+    }
+
+    @Test
+    void getDetailReturnsFrontOnlyWhenBackBlank() {
+        var entry = signEntry(parsed("[poi]", "Town Hall", "Open 9-5"), empty());
+
+        assertEquals("Open 9-5", SignEntryHelper.getDetail(entry));
+    }
+
+    @Test
+    void getDetailReturnsBackOnlyWhenFrontBlank() {
+        var entry = signEntry(empty(), parsed("[poi]", "Fair", "Ask for Bob"));
+
+        assertEquals("Ask for Bob", SignEntryHelper.getDetail(entry));
+    }
+
+    @Test
+    void getDetailCombinesBothSidesWhenNeitherBlank() {
+        var entry = signEntry(parsed("[poi]", "Town Hall", "Open 9-5"), parsed("[poi]", "Fair", "Ask for Bob"));
+
+        assertEquals(String.format("FRONT: %s%nBACK: %s", "Open 9-5", "Ask for Bob"), SignEntryHelper.getDetail(entry));
+    }
+}


### PR DESCRIPTION
## What

Makes marker-group config hot-reloadable: editing BMSM-Core.json and running /bluemap reload now picks up the new group definitions without a server restart.

## Why

Config was previously frozen at class-init in three places (ConfigManager.coreConfig, SignHelper.signLinesParser, SignManager.prefixGroupMap), so a /bluemap reload already replayed the sign cache but with stale group data (old icons/offsets/visibility/distances). See plans/marker-group-config-reload-plan.md.

## Changes

- ConfigManager: coreConfig is now volatile; added reload() to reload from disk.
- SignHelper: signLinesParser is now volatile; added reloadParser() to rebuild it from current config.
- SignManager: prefixGroupMap and actionFactory are now volatile; reset() calls a new reloadConfig() (reloads ConfigManager, rebuilds the parser, prefix map, and ActionFactory) before reloadSigns().
- SignEntryHelper.isMarkerType: null-checks the group lookup so a sign whose prefix was removed/renamed during a reload doesn't NPE.
- BlueMapAPIConnector.onEnable: sets blueMapAPI before firing reset, so the reset path has a valid API reference.
- Added SignEntryHelperTest covering prefix/label/detail resolution and the now-fixed null-prefix case.
- Added plans/marker-group-config-reload-plan.md and plans/marker-group-reload-followups-todo.md.

## Testing

- ./gradlew test — new SignEntryHelperTest cases pass.
- Manual: ./gradlew runServer, edit BMSM-Core.json (e.g. change an icon/prefix), run /bluemap reload in-game, confirm existing markers update to the new definitions without a restart.