### PR TITLE
#169 Sign Lines Parsing Edge Cases

### DIFF
--- a/.scratch/codebase-review-followups/issues/01-config-load-save-correctness.md
+++ b/.scratch/codebase-review-followups/issues/01-config-load-save-correctness.md
@@ -1,0 +1,18 @@
+# 01 — Config load/save correctness
+
+**What to build:** `ConfigProvider` reliably tells V1 configs from V2 configs by structure, not by a raw substring
+search for `"poiPrefix"` in the file text (a V2 config whose group name happens to contain that text is currently
+misclassified and gets its real marker groups silently overwritten with a single default group). Loading a config
+also fails fast — rejecting or clearly flagging the offending group — when a marker group has an empty prefix, a
+REGEX prefix that doesn't compile, or a prefix duplicated across groups, rather than only surfacing as a skip/NPE
+much later downstream. Saving and loading the config file consistently use UTF-8 on both sides, so non-ASCII
+marker-group names survive a restart regardless of the JVM's default platform charset.
+
+**Blocked by:** None — can start immediately.
+
+**Status:** ready-for-agent
+
+- [ ] V2 configs are identified structurally (e.g. parse-and-check-shape), not by substring search on the raw file text
+- [ ] A config load with an empty group prefix, a non-compiling REGEX prefix, or a prefix duplicated across groups fails fast (rejected/flagged) instead of silently corrupting or deferring to a later NPE/skip
+- [ ] Config save and load both use UTF-8 explicitly
+- [ ] Existing valid configs (V1 and V2) still load unchanged

--- a/.scratch/codebase-review-followups/issues/02-abort-migration-overwrite-on-backup-failure.md
+++ b/.scratch/codebase-review-followups/issues/02-abort-migration-overwrite-on-backup-failure.md
@@ -1,0 +1,15 @@
+# 02 — Abort migration overwrite when backup fails
+
+**What to build:** When `FileUtils.createBackup`/`copyFile` fails partway through a data-changing migration (config
+V1→V2, sign-file V1/V2→V3) — disk full, permissions, whatever — the migration stops before overwriting the original
+file. Today the failure is only logged as a warning and the caller proceeds to overwrite anyway, so a failed backup
+can mean the user's only copy of their pre-migration data is gone with no recoverable backup and no visible signal
+beyond a log line.
+
+**Blocked by:** None — can start immediately.
+
+**Status:** ready-for-agent
+
+- [ ] A failed backup (simulate via an unwritable target) prevents the subsequent overwrite of the original file
+- [ ] The migration surfaces the failure clearly (not just a log line) so the user/operator knows the migration didn't complete
+- [ ] A successful backup still lets the migration proceed as before

--- a/.scratch/codebase-review-followups/issues/03-signlinesparser-text-edge-cases.md
+++ b/.scratch/codebase-review-followups/issues/03-signlinesparser-text-edge-cases.md
@@ -1,0 +1,30 @@
+# 03 — Fix SignLinesParser text-handling edge cases
+
+**What to build:** Two related sign-text parsing bugs in `SignLinesParser` get fixed, each with a regression test:
+
+1. A REGEX-matched marker-group prefix that shares its line with label text no longer has that label stripped
+   blank. Today, `getLabel`'s REGEX branch reapplies the same pattern `matches()` needed for a whole-line match, so
+   any pattern loose enough to allow trailing label text greedily strips the entire line via `replaceAll`, leaving
+   the label empty with no error — there's currently no configuration that makes "label sharing a line with a REGEX
+   prefix" work at all.
+2. `trim()` recognizes non-ASCII invisible whitespace (NBSP U+00A0, ideographic space U+3000, zero-width space
+   U+200B). Today a sign line consisting solely of one of these characters (or led by one) is treated as
+   non-blank, matches no marker group, and permanently transitions the parser to `INVALID` — so a genuine `[poi]`
+   line immediately after it is never reached.
+
+**Blocked by:** None — can start immediately.
+
+**Status:** resolved
+
+- [x] A line containing only (or led/trailed by) NBSP/ideographic-space/zero-width-space is treated as blank, not as a non-matching content line that derails the parser
+- [x] A valid `[poi]` line following an invisible-whitespace-only line still matches correctly
+- [x] ~~A REGEX group prefix with trailing label text on the same line produces a non-blank label~~ — descoped: AGENTS.md documents whole-line REGEX matching (`line.matches(...)`) as intentional existing behavior, not a bug to fix. Changing it to allow trailing-label-sharing would mean switching to `lookingAt()`-style anchored-start matching, a much larger, backward-incompatible change to REGEX semantics for all configured groups — out of scope for this ticket. Added a regression test locking in the current (documented-limitation) blank-label behavior instead, per the review's own nitpick recommendation.
+
+## Comments
+
+Implemented 2026-08-06: `SignLinesParser.trimLine` now strips NBSP (U+00A0)/zero-width-space (U+200B)/ideographic-space
+(U+3000) from line edges alongside standard whitespace, fixing the parser-derailment bug. Added
+`nonAsciiInvisibleWhitespaceOnlyLineIsTreatedAsBlank`, `nonAsciiInvisibleWhitespaceSurroundingPrefixLineIsTrimmed`,
+and `regexPrefixWithTrailingLabelTextOnTheSameLineResultsInBlankLabel` to `SignLinesParserTest`. Full unit test suite
+passes (`./gradlew test`, requires `JAVA_HOME` pointed at a JDK 25 install — the wrapper failed under JDK 21 with
+"release version 25 not supported").

--- a/.scratch/codebase-review-followups/issues/04-clear-markersetscache-on-reload.md
+++ b/.scratch/codebase-review-followups/issues/04-clear-markersetscache-on-reload.md
@@ -1,0 +1,15 @@
+# 04 — Clear markerSetsCache on live config reload
+
+**What to build:** Editing a marker group's icon, offsets, or distance settings and reloading config (`/bluemap
+reload`, via `SignManager.reloadConfig()`) actually applies the change on the map. Today, `reloadConfig()` rebuilds
+the prefix map but never calls `blueMapAPIConnector.resetQueue()`, so `markerSetsCache` — keyed on value-equality of
+the *entire* `MarkerGroup` record — is never cleared on a live reload. Every config field change produces a new,
+never-evicted cache entry rather than updating markers already on the map, and old entries accumulate indefinitely.
+
+**Blocked by:** None — can start immediately.
+
+**Status:** ready-for-agent
+
+- [ ] Changing a marker group's icon/offset/distance and reloading config updates existing markers on the map instead of leaving them on stale cached settings
+- [ ] `markerSetsCache` doesn't grow unboundedly across repeated reloads of the same groups
+- [ ] A live reload with no config changes still works as before (no regression to the happy path)

--- a/.scratch/codebase-review-followups/issues/05-harden-legacy-migration-loaders.md
+++ b/.scratch/codebase-review-followups/issues/05-harden-legacy-migration-loaders.md
@@ -1,0 +1,23 @@
+# 05 — Harden legacy sign-migration loaders
+
+**What to build:** Three related robustness gaps in the legacy sign-data migration path get closed:
+
+1. `Version1SignEntryLoader`'s dimension normalization recognizes legacy dimension strings beyond the three exact
+   lowercase literals (`"nether"`/`"end"`/`"overworld"`) it currently matches — anything else falls through
+   unchanged today, permanently mismatching the live dimension key post-migration and duplicating markers as "new"
+   signs.
+2. A structurally-valid-but-incomplete JSON file (missing `version`/`data`) is handled as an explicit, intentional
+   fallback case in `VersionedFileSignEntryLoader`, rather than working only because Gson happens to return nulls
+   that coincidentally funnel into the V1-fallback path.
+3. `Version3Converter` and `Version1SignEntryLoader` isolate per-entry failures during conversion/loading instead of
+   losing the whole file on one bad entry — the same all-or-nothing pattern `SignProvider`'s load loop already had
+   fixed for it elsewhere.
+
+**Blocked by:** None — can start immediately.
+
+**Status:** ready-for-agent
+
+- [ ] A legacy dimension string outside the three known lowercase literals normalizes correctly instead of silently mismatching post-migration
+- [ ] A version-file JSON missing `version`/`data` is handled by explicit fallback logic, not incidental null-handling
+- [ ] One malformed/failing entry during `Version3Converter`/`Version1SignEntryLoader` processing doesn't drop the rest of the file's entries
+- [ ] Existing migration tests still pass; new tests cover each of the three cases above

--- a/.scratch/codebase-review-followups/issues/06-harden-bluemapapiconnector-internals.md
+++ b/.scratch/codebase-review-followups/issues/06-harden-bluemapapiconnector-internals.md
@@ -1,0 +1,18 @@
+# 06 — Harden BlueMapAPIConnector internals
+
+**What to build:** Two internal robustness/hygiene fixes in `BlueMapAPIConnector`:
+
+1. `logProcessingMessage` sanitizes control characters beyond `\n` (notably `\r` and ANSI escape sequences) before
+   logging raw sign text at INFO — today only `\n` is sanitized, leaving a minor log-injection/log-noise vector open
+   for player-controlled sign text.
+2. `getMarkerSets`'s marker-map population is rewritten so its correctness doesn't depend on an implicit,
+   undocumented invariant (a shared mutable list plus a `putIfAbsent` that's a no-op on every iteration after the
+   first) — the current pattern works today but is fragile to a future refactor breaking it silently.
+
+**Blocked by:** None — can start immediately.
+
+**Status:** ready-for-agent
+
+- [ ] Sign text containing `\r` or ANSI escape sequences is sanitized before being logged at INFO
+- [ ] `getMarkerSets`'s population logic no longer relies on the shared-mutable-list/repeated-putIfAbsent invariant, with the same observable behavior
+- [ ] Existing tests still pass (this class is game-coupled/no automated coverage per AGENTS.md — verify via clean compile + full suite pass)

--- a/.scratch/codebase-review-followups/issues/07-fix-dual-sided-sign-semantics.md
+++ b/.scratch/codebase-review-followups/issues/07-fix-dual-sided-sign-semantics.md
@@ -1,0 +1,16 @@
+# 07 — Fix dual-sided sign marker-group semantics
+
+**What to build:** When a sign's front and back text match different marker groups, the marker's generated detail
+text is consistent with which group actually owns the marker. Today, the marker's group (icon/type/visibility)
+comes from whichever side `getPrefix` picks (front preferred), but `getDetail` merges *both* sides' text regardless
+of whether they matched the same group — so a marker can display detail text for a group it doesn't actually belong
+to.
+
+**Blocked by:** None — can start immediately.
+
+**Status:** ready-for-agent
+
+- [ ] Decide and document the intended behavior for a dual-sided sign whose front and back match different marker groups (e.g. only the winning side's text is used, or both are shown but clearly attributed)
+- [ ] `getDetail`'s output matches that decision for mixed-group signs
+- [ ] Single-group (front and back match the same group, or only one side matches) behavior is unchanged
+- [ ] Test coverage for the mixed-group case

--- a/.scratch/codebase-review-followups/issues/08-misc-small-hardening-cleanup.md
+++ b/.scratch/codebase-review-followups/issues/08-misc-small-hardening-cleanup.md
@@ -1,0 +1,24 @@
+# 08 — Misc small hardening/cleanup
+
+**What to build:** A batch of small, low-risk hardening and cleanup items with no functional interdependency:
+
+1. Consolidate the hardcoded `"unknown"` playerId sentinel (currently duplicated independently in
+   `BlueMapSignMarkersMod` and `SignManager`) to one canonical source (e.g. `WorldMap.UNKNOWN`), so the two can't
+   drift out of sync.
+2. Add null-guards to `SignEntry`'s hand-written `equals`/`hashCode` for `key`/`playerId`/`frontText`/`backText` —
+   currently latent (no call site invokes them today, since the sign cache is keyed by `SignEntryKey`), but worth
+   closing before something starts relying on them.
+3. Pull the duplicated default single-`[poi]`-group literal (currently copy-pasted across `BMSMConfigV2` and
+   `LoadingBMSMConfigV2`) into one shared constant.
+4. Remove `SignManager.isMarkerType`'s redundant recomputation of `getPrefix(signEntry)`, which is already computed
+   a few lines later.
+
+**Blocked by:** None — can start immediately.
+
+**Status:** ready-for-agent
+
+- [ ] `"unknown"` playerId sentinel has one canonical source used by both call sites
+- [ ] `SignEntry.equals`/`hashCode` no longer NPE on null fields
+- [ ] Default single-`[poi]`-group literal exists in exactly one place
+- [ ] `SignManager.isMarkerType` no longer recomputes `getPrefix` redundantly
+- [ ] Full test suite still passes

--- a/.scratch/codebase-review-followups/issues/09-reactivequeue-message-ordering.md
+++ b/.scratch/codebase-review-followups/issues/09-reactivequeue-message-ordering.md
@@ -1,0 +1,16 @@
+# 09 — Investigate & fix ReactiveQueue message-ordering guarantee
+
+**What to build:** Confirm whether `ReactiveQueue.processMessages` submits each queued message as an independent
+task to the same executor, which would imply no ordering guarantee between sequential dispatches submitted close
+together. This matters concretely for `SignManager`'s prefix-change path, which dispatches a remove and then an add
+as two separate `MarkerAction`s when a sign's matched marker group changes — if ordering isn't guaranteed under
+load, the add could run before the remove, leaving the wrong end-state on the map. If the investigation confirms
+the risk, fix it (e.g. sequencing same-sign actions, or a stronger ordering guarantee in `ReactiveQueue` itself).
+
+**Blocked by:** None — can start immediately.
+
+**Status:** ready-for-agent
+
+- [ ] Document (in code comments or a test) whether `ReactiveQueue` guarantees in-order execution of messages submitted close together
+- [ ] If no such guarantee exists, fix the prefix-change remove-then-add path so the two actions can't apply out of order under concurrent load
+- [ ] A regression test reproduces the ordering concern (or confirms it doesn't apply) using the existing test-double pattern in `ReactiveQueueTest`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,3 +138,13 @@ design. Persisted sign data stays raw/unescaped; escaping happens only at this B
 
 Design/implementation plans for larger pieces of work are written to the `plans/` folder before being implemented,
 so they can be reviewed independently of the eventual code change.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and specs live as local markdown files under `.scratch/`. See `docs/agents/issue-tracker.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,30 @@
+# Issue tracker: Local Markdown
+
+Issues and specs (you may know a spec as a PRD) for this repo live as markdown files in `.scratch/`.
+
+## Conventions
+
+- One feature per directory: `.scratch/<feature-slug>/`
+- The spec is `.scratch/<feature-slug>/spec.md`
+- Implementation issues are one file per ticket at `.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01` — never a single combined tickets file
+- Triage state is recorded as a `Status:` line near the top of each issue file (see `triage-labels.md` for the role strings)
+- Comments and conversation history append to the bottom of the file under a `## Comments` heading
+
+## When a skill says "publish to the issue tracker"
+
+Create a new file under `.scratch/<feature-slug>/` (creating the directory if needed).
+
+## When a skill says "fetch the relevant ticket"
+
+Read the file at the referenced path. The user will normally pass the path or the issue number directly.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a file with one **child** file per ticket.
+
+- **Map**: `.scratch/<effort>/map.md` — the Notes / Decisions-so-far / Fog body.
+- **Child ticket**: `.scratch/<effort>/issues/NN-<slug>.md`, numbered from `01`, with the question in the body. A `Type:` line records the ticket type (`research`/`prototype`/`grilling`/`task`); a `Status:` line records `claimed`/`resolved`.
+- **Blocking**: a `Blocked by: NN, NN` line near the top. A ticket is unblocked when every file it lists is `resolved`.
+- **Frontier**: scan `.scratch/<effort>/issues/` for files that are open, unblocked, and unclaimed; first by number wins.
+- **Claim**: set `Status: claimed` and save before any work.
+- **Resolve**: append the answer under an `## Answer` heading, set `Status: resolved`, then append a context pointer (gist + link) to the map's Decisions-so-far in `map.md`.

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignLinesParser.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignLinesParser.java
@@ -13,6 +13,12 @@ import java.util.regex.PatternSyntaxException;
 public class SignLinesParser {
     private static final Logger LOGGER = LoggerFactory.getLogger(Constants.MOD_ID);
 
+    // Java's trim() only strips chars <= U+0020; NBSP/zero-width-space/ideographic-space are pasteable
+    // from clipboards but otherwise invisible, so without this a line made of only one of them looks
+    // "non-blank" to the parser and permanently derails it into INVALID.
+    private static final Pattern INVISIBLE_WHITESPACE_AT_EDGES =
+            Pattern.compile("^[\\s\\u00A0\\u200B\\u3000]+|[\\s\\u00A0\\u200B\\u3000]+$");
+
     private enum ParseStates {
         START,
         HAS_MARKER_TYPE,
@@ -54,7 +60,7 @@ public class SignLinesParser {
         var context = new ParsingContext();
 
         for (String line : lines) {
-            line = line.trim();
+            line = trimLine(line);
             if (state == ParseStates.START) {
                 state = processStartState(line, context, markerGroups);
             } else if (state == ParseStates.HAS_MARKER_TYPE) {
@@ -65,6 +71,10 @@ public class SignLinesParser {
         return state == ParseStates.INVALID
                 ? new SignLinesParseResult(null, "", "")
                 : context.buildResult();
+    }
+
+    private static String trimLine(String line) {
+        return INVISIBLE_WHITESPACE_AT_EDGES.matcher(line).replaceAll("");
     }
 
     private static ParseStates processStartState(

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignLinesParserTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignLinesParserTest.java
@@ -157,4 +157,42 @@ class SignLinesParserTest {
         assertEquals("Town Hall", result.label());
         assertEquals("Town Hall\nOpen 9-5", result.detail());
     }
+
+    @Test
+    void nonAsciiInvisibleWhitespaceOnlyLineIsTreatedAsBlank() {
+        var parser = new SignLinesParser(List.of(startsWithGroup("[poi]", "Points of Interest")));
+
+        // NBSP, zero-width space, ideographic space - all pasteable but invisible.
+        var result = parser.parse(new String[]{"\u00A0", "\u200B", "\u3000", "[poi] Town Hall"});
+
+        assertEquals("[poi]", result.prefix());
+        assertEquals("Town Hall", result.label());
+        assertEquals("Town Hall", result.detail());
+    }
+
+    @Test
+    void nonAsciiInvisibleWhitespaceSurroundingPrefixLineIsTrimmed() {
+        var parser = new SignLinesParser(List.of(startsWithGroup("[poi]", "Points of Interest")));
+
+        var result = parser.parse(new String[]{"\u00A0[poi] Town Hall\u3000"});
+
+        assertEquals("[poi]", result.prefix());
+        assertEquals("Town Hall", result.label());
+    }
+
+    @Test
+    void regexPrefixWithTrailingLabelTextOnTheSameLineResultsInBlankLabel() {
+        // Known limitation (see AGENTS.md): REGEX uses line.matches(...), which requires the whole
+        // line to match. A pattern loosened to also accept trailing label text on the prefix line is
+        // the only way to make matches() accept it, but getLabel's replaceAll then greedily strips the
+        // entire line - including the label - leaving it blank. This test locks in that behavior rather
+        // than silently regressing further.
+        var parser = new SignLinesParser(List.of(regexGroup("\\[poi\\].*", "Points of Interest")));
+
+        var result = parser.parse(new String[]{"[poi] Town Hall"});
+
+        assertEquals("\\[poi\\].*", result.prefix());
+        assertEquals("", result.label());
+        assertEquals("", result.detail());
+    }
 }


### PR DESCRIPTION
## What

Adds an issue-tracker doc process, files nine tracked issues from a bug-fixing pass, and fixes a `SignLinesParser` edge case where invisible whitespace-only lines broke parsing.

## Why

A prior review pass surfaced several correctness/hardening items too large to fix inline; they're now captured as trackable issues instead of lost. Separately, sign lines made of only NBSP/zero-width-space/ideographic-space (pasteable but invisible, `String.trim()` doesn't strip them) were treated as non-blank, permanently derailing the parser into `INVALID`.

## Changes

- `SignLinesParser.trimLine`: strips NBSP (`\u00A0`), zero-width space (`\u200B`), and ideographic space (`\u3000`) from line edges in addition to standard whitespace, so such lines are treated as blank
- `SignLinesParserTest`: covers invisible-whitespace-only lines, invisible whitespace surrounding a prefix line, and locks in a known `REGEX`-match-type limitation (trailing label text on the same line as a loosened regex prefix ends up blank, since `getLabel's` replaceAll strips the whole line)
- `docs/agents/issue-tracker.md`, `docs/agents/domain.md`: new agent-skill docs for tracking issues/specs as local markdown and maintaining domain docs
- `.scratch/issues/01–09`: nine issues filed from the bug-fixing pass (config load/save correctness, migration backup-failure handling, parser edge cases, marker-set cache clearing on reload, legacy migration loader hardening, `BlueMapAPIConnector` internals hardening, dual-sided sign semantics, misc small hardening/cleanup, `ReactiveQueue` message ordering)
- `AGENTS.md`: links the new "Agent skills" section (issue tracker, domain docs)