### PR TITLE
#8 Shape markers

### DIFF
--- a/.scratch/shape-markers/issues/01-core-shape-marker-happy-path.md
+++ b/.scratch/shape-markers/issues/01-core-shape-marker-happy-path.md
@@ -1,7 +1,7 @@
 # 01 — Core SHAPE marker type: create/update/remove happy path
 
 **What to build:** A new `SHAPE` marker group type. Placing 3 or more signs that share a `SHAPE` group's prefix and
-identical label text renders a filled polygon on the map, anchored at the Y height of the first-placed member and
+identical label text renders a filled polygon on the map, anchored at the Y height of the tallest member and
 ordered by placement time. Editing any member's text (same prefix/label) updates the shape's detail popup without
 breaking or duplicating the marker. Removing members back down to 2 or fewer removes the marker.
 

--- a/.scratch/shape-markers/issues/01-core-shape-marker-happy-path.md
+++ b/.scratch/shape-markers/issues/01-core-shape-marker-happy-path.md
@@ -1,0 +1,75 @@
+# 01 — Core SHAPE marker type: create/update/remove happy path
+
+**What to build:** A new `SHAPE` marker group type. Placing 3 or more signs that share a `SHAPE` group's prefix and
+identical label text renders a filled polygon on the map, anchored at the Y height of the first-placed member and
+ordered by placement time. Editing any member's text (same prefix/label) updates the shape's detail popup without
+breaking or duplicating the marker. Removing members back down to 2 or fewer removes the marker.
+
+See `.scratch/shape-markers/spec.md` for full context (Implementation/Testing Decisions sections) and
+`docs/adr/0001-shape-points-insertion-order-no-validation.md` / `docs/adr/0002-shape-duplicates-line-pattern.md`
+for the design constraints this must follow.
+
+**Blocked by:** None — can start immediately.
+
+**Status:** ready-for-review
+
+- [x] `MarkerGroupType.SHAPE` exists alongside `POI`/`LINE`.
+- [x] `MarkerGroup` gains a `fillColor` field (hex-with-optional-alpha, same format/parsing as `lineColor`); a
+      missing or malformed value falls back to a translucent default (e.g. `#FF000033`) and logs a warning on
+      malformed input, mirroring `resolveLineColor`'s existing pattern.
+- [x] `lineWidth`/`lineColor` are valid (non-ignored, non-warned) fields on `SHAPE` groups, matching their existing
+      `LINE` behavior.
+- [x] `ShapeGroupResolver.members(...)` resolves a shape's members (same parent map, prefix, label), ordered by
+      `createdAtMillis`, mirroring `LineGroupResolver.members`.
+- [x] `SetShapeMarkerAction`/`RemoveShapeMarkerAction`/`ShapeMarkerIdentifier` (id scheme `"shape:" + label`) exist,
+      mirroring the `Line` equivalents.
+- [x] `ActionFactory.createSetShapeAction(...)`/`createRemoveShapeAction(...)` exist, mirroring the `Line`
+      equivalents.
+- [x] `SignTransitionResolver.computeTransitionAction` handles the `SHAPE`↔`SHAPE` same-group case: join/recompute
+      at 1→2 members (no-op), 2→3 (first appearance), 3→4+ (recompute); leave/recompute at 4→3 (recompute), 3→2
+      (remove), 2→1/1→0 (no-op) — mirroring the existing `LINE`↔`LINE` branch and its 2-member threshold, but at 3.
+- [x] `BlueMapAPIConnector` renders a `SetShapeMarkerAction` as a flat BlueMap `ShapeMarker` (polygon from the
+      ordered points' x/z, anchor Y from the oldest member, `fillColor`, `lineWidth`, `lineColor`) and handles
+      `RemoveShapeMarkerAction`, with matching `case` arms in both `processMarkerAction` and
+      `logProcessingMessage` (per `AGENTS.md` — `MarkerAction` is unsealed, so a missing case silently falls
+      through to `default`).
+- [x] Unit tests: `SignTransitionResolverTest` (new `SHAPE` join/leave/recompute rows), new `ShapeGroupResolverTest`,
+      `ActionFactoryTest` additions for the new create/remove methods, `ConfigProviderTest` additions for
+      `fillColor` default/malformed-fallback resolution.
+- [ ] Manually verified via `runServer`: placing/editing/removing signs produces the expected polygon
+      creation/update/removal in BlueMap's web UI.
+
+## Comments
+
+Implemented all automated-scope items. `MarkerGroupType.SHAPE` added; `MarkerGroup` gained `fillColor` (13th
+constructor arg — every call site across main/test updated); `ShapeMarkerIdentifier`/`SetShapeMarkerAction`/
+`RemoveShapeMarkerAction`/`ShapeGroupResolver` mirror the `Line` equivalents (`ShapeGroupResolver.members`
+delegates straight to `LineGroupResolver.members` since the filter/sort logic is identical - see ADR 0002).
+`ActionFactory` gained `createSetShapeAction`/`createRemoveShapeAction`.
+
+`SignTransitionResolver.computeTransitionAction` was refactored around two new dispatch helpers, `leaveEffect`/
+`joinEffect`, that switch on `MarkerGroupType` (`POI`/`LINE`/`SHAPE`) instead of hardcoding a POI-vs-LINE binary;
+this made the SHAPE↔SHAPE same-group branch a one-line addition to the existing LINE↔LINE check
+(`oldType == newType && oldType != POI && sameGroupAndLabel(...)`) and, as a side effect, gave every POI/LINE/SHAPE
+type-flip combination for free through the existing generic leave+join bundling path — so ticket 02's scope
+(`POI`/`LINE`↔`SHAPE` flips, including the reload/`isReload` variants) is also covered, verified with dedicated
+`SignTransitionResolverTest` cases for both directions. `shapeJoinAction`/`shapeLeaveAction` mirror
+`lineJoinAction`/`lineLeaveAction` at a 3-member threshold instead of 2.
+
+`BlueMapAPIConnector` renders `SetShapeMarkerAction` via BlueMap's `ShapeMarker` builder: polygon from points'
+x/z (`Shape`), anchor Y from `points.get(0)` (oldest member, since points stay ordered by `createdAtMillis`),
+plus `fillColor`/`lineWidth`/`lineColor`; matching `case` arms added to both `processMarkerAction`'s and
+`logProcessingMessage`'s switches per `AGENTS.md`'s unsealed-`MarkerAction` warning.
+
+`ConfigProvider` widened `resolveLineWidth`/`resolveLineColor`'s validation scope from LINE-only to LINE/SHAPE,
+added `resolveFillColor` (SHAPE-only, default `#FF000033`), and added the mismatch warnings ticket 03 asked for
+(`icon`/`offsetX`/`offsetY` on SHAPE, `fillColor` on POI/LINE) - so ticket 03 is covered too. `README.md` documents
+`SHAPE` as a `type` value, `fillColor`, the widened `lineWidth`/`lineColor` scope, and an example `SHAPE` group -
+covering ticket 04.
+
+All four `.scratch/shape-markers/issues/0{1,2,3,4}-*.md` checklists reflect this; each now has an equivalent
+Comments note. `./gradlew build` (compiles + all 248 unit tests, including new `ShapeGroupResolverTest` and the
+`SignTransitionResolverTest`/`ActionFactoryTest`/`ConfigProviderTest` additions) passes. The one item still open
+across all four tickets is the manual `runServer` in-game verification (placing/editing/removing signs and
+confirming the polygon/type-flip behavior in BlueMap's web UI), which is out of this session's scope per
+`AGENTS.md`'s testable-vs-game-coupled split.

--- a/.scratch/shape-markers/issues/01-core-shape-marker-happy-path.md
+++ b/.scratch/shape-markers/issues/01-core-shape-marker-happy-path.md
@@ -29,7 +29,7 @@ for the design constraints this must follow.
       at 1→2 members (no-op), 2→3 (first appearance), 3→4+ (recompute); leave/recompute at 4→3 (recompute), 3→2
       (remove), 2→1/1→0 (no-op) — mirroring the existing `LINE`↔`LINE` branch and its 2-member threshold, but at 3.
 - [x] `BlueMapAPIConnector` renders a `SetShapeMarkerAction` as a flat BlueMap `ShapeMarker` (polygon from the
-      ordered points' x/z, anchor Y from the oldest member, `fillColor`, `lineWidth`, `lineColor`) and handles
+      ordered points' x/z, anchor Y from the tallest member, `fillColor`, `lineWidth`, `lineColor`) and handles
       `RemoveShapeMarkerAction`, with matching `case` arms in both `processMarkerAction` and
       `logProcessingMessage` (per `AGENTS.md` — `MarkerAction` is unsealed, so a missing case silently falls
       through to `default`).
@@ -57,9 +57,22 @@ type-flip combination for free through the existing generic leave+join bundling 
 `lineJoinAction`/`lineLeaveAction` at a 3-member threshold instead of 2.
 
 `BlueMapAPIConnector` renders `SetShapeMarkerAction` via BlueMap's `ShapeMarker` builder: polygon from points'
-x/z (`Shape`), anchor Y from `points.get(0)` (oldest member, since points stay ordered by `createdAtMillis`),
+x/z (`Shape`), anchor Y from the tallest member (`max` across all current points' y, not placement order - a
+deliberate deviation from the original plan of anchoring to the oldest/first-placed member, per user feedback),
 plus `fillColor`/`lineWidth`/`lineColor`; matching `case` arms added to both `processMarkerAction`'s and
 `logProcessingMessage`'s switches per `AGENTS.md`'s unsealed-`MarkerAction` warning.
+
+**Follow-up fix (post-review):** two bugs found in manual review before `runServer` verification:
+1. `fillColor`/`lineColor` rendered fully opaque regardless of configured alpha. Root cause: BlueMap's
+   `Color(int, int, int, float alpha)` constructor takes alpha in **0-1**, but `ColorUtils.parseHex` returns
+   alpha in **0-255** (matching r/g/b) - passing that int straight into the float parameter widens it (e.g.
+   `51` becomes `51.0f`) instead of the intended `51/255f ≈ 0.2f`, which BlueMap then clamps to opaque. Fixed
+   with a new `toBlueMapColor(int[] rgba)` helper (`rgba[3] / 255f`), used by both `setShapeMarker` and the
+   pre-existing `setLineMarker` (same bug, latent there too - just never visible since `LINE`'s default alpha
+   is opaque `FF` anyway).
+2. Shape Y-anchor changed from "oldest (first-placed) member" to "tallest member" (max Y across all current
+   members) per explicit user feedback - a deviation from `spec.md`'s original plan, now updated there too.
+   Point order (by `createdAtMillis`) is unchanged and still only governs polygon vertex order, not height.
 
 `ConfigProvider` widened `resolveLineWidth`/`resolveLineColor`'s validation scope from LINE-only to LINE/SHAPE,
 added `resolveFillColor` (SHAPE-only, default `#FF000033`), and added the mismatch warnings ticket 03 asked for

--- a/.scratch/shape-markers/issues/02-shape-type-flip-transitions.md
+++ b/.scratch/shape-markers/issues/02-shape-type-flip-transitions.md
@@ -1,0 +1,41 @@
+# 02 — Type-flip transitions: POI/LINE ↔ SHAPE, and reload self-heal
+
+**What to build:** Moving a sign between a `POI`/`LINE` group and a `SHAPE` group (by editing its prefix so it now
+matches a different group) removes the old marker and adds/updates the new one, with no orphaned marker left behind
+in BlueMap's UI — matching the existing `POI`↔`LINE` type-flip behavior. Separately, editing a `SHAPE` group's
+`type` in config (e.g. `SHAPE` → `LINE` or vice versa) and running `/bluemap reload` self-heals every affected sign
+without a server restart, the same way `POI`↔`LINE` type flips already self-heal today.
+
+See `.scratch/shape-markers/spec.md` for full context.
+
+**Blocked by:** 01 — requires the core `SHAPE` join/leave/recompute logic and `ShapeMarkerIdentifier`/action types.
+
+**Status:** ready-for-review
+
+- [x] `SignTransitionResolver.computeTransitionAction` handles every remaining `POI`/`LINE`/`SHAPE` combination
+      (`POI`→`SHAPE`, `SHAPE`→`POI`, `LINE`→`SHAPE`, `SHAPE`→`LINE`, in both directions), dispatching a
+      `GroupTransitionMarkerAction` bundling the old representation's leave-effect and the new representation's
+      join-effect, mirroring the existing `POI`↔`LINE` generic branch.
+- [x] A sign moving out of a `SHAPE` group correctly recomputes/removes the old shape based on remaining membership
+      (same leave semantics as ticket 01's `SHAPE`↔`SHAPE` leave case).
+- [x] A sign moving into a `SHAPE` group correctly recomputes/creates the new shape based on resulting membership
+      (same join semantics as ticket 01's `SHAPE`↔`SHAPE` join case).
+- [x] `SignManager.reloadConfig()`'s reload self-heal path (`IResetHandler.reset()`) correctly diffs old-vs-new
+      representation for every cached sign when a `SHAPE` group's `type` changes in config, dispatching the same
+      transition actions as a live prefix edit would.
+- [x] Unit tests: `SignTransitionResolverTest` rows for every `POI`/`LINE`↔`SHAPE` combination, including the
+      `isReload` variants (mirroring the existing `POI`↔`LINE` reload test coverage).
+- [ ] Manually verified via `runServer`: editing a sign's prefix across `POI`/`LINE`/`SHAPE` groups, and flipping a
+      `SHAPE` group's `type` in config followed by `/bluemap reload`, leave no orphaned markers in BlueMap's UI.
+
+## Comments
+
+Completed as a side effect of ticket 01: `SignTransitionResolver.computeTransitionAction` was refactored so
+`leaveEffect`/`joinEffect` dispatch on `MarkerGroupType` generically (POI/LINE/SHAPE) rather than a POI-vs-other
+binary, so the existing leave+join bundling path already covers every `POI`/`LINE`/`SHAPE` type-flip combination
+without type-pair-specific code. `SignManager.reloadConfig()`'s self-heal needed no changes - it was already
+generic over `Representation`/`computeTransitionAction`, with no hardcoded `MarkerGroupType` branching of its own.
+Added dedicated `SignTransitionResolverTest` cases: `poiToShapeBundlesRemovePoiAndSetShape`,
+`shapeToPoiBundlesSetShapeAndAddPoi`, `lineToShapeBundlesRemoveLineAndSetShape`,
+`shapeToLineBundlesRemoveShapeAndSetLine`, and an `isReload` variant of each four. See ticket 01's Comments for
+the full implementation summary. Manual `runServer` verification still outstanding.

--- a/.scratch/shape-markers/issues/03-shape-config-field-mismatch-warnings.md
+++ b/.scratch/shape-markers/issues/03-shape-config-field-mismatch-warnings.md
@@ -1,0 +1,30 @@
+# 03 — Config validation polish: field-mismatch warnings
+
+**What to build:** A server admin who sets a `POI`/`LINE`-only field (`icon`, `offsetX`, `offsetY`) on a `SHAPE`
+group, or sets `fillColor` on a `POI`/`LINE` group, sees a warning logged and the field ignored — never a crash or
+silent unexpected behavior. This matches the existing warn-and-ignore convention `ConfigProvider` already applies
+for `LINE` groups with `icon`/`offsetX`/`offsetY` set.
+
+See `.scratch/shape-markers/spec.md` for full context.
+
+**Blocked by:** 01 — requires `MarkerGroupType.SHAPE` and the `fillColor` field to exist.
+
+**Status:** resolved
+
+- [x] Setting `icon` on a `SHAPE` group logs a warning ("...is type SHAPE but has 'icon' set...") and the field is
+      ignored, mirroring the existing `LINE` warning.
+- [x] Setting `offsetX` or `offsetY` on a `SHAPE` group logs a warning and the field is ignored, mirroring the
+      existing `LINE` warnings.
+- [x] Setting `fillColor` on a `POI` or `LINE` group logs a warning ("...is type POI/LINE but has 'fillColor'
+      set...") and the field is ignored.
+- [x] Unit tests: `ConfigProviderTest` additions covering each of the above mismatch cases.
+
+## Comments
+
+Completed as a side effect of ticket 01: `ConfigProvider.warnOnTypeFieldMismatches` gained a `SHAPE` branch
+(warns on `icon`/`offsetX`/`offsetY`, mirroring the existing `LINE` branch) and a `fillColor` check in both the
+`POI` and `LINE` branches. Field values are still loaded (not nulled out) despite the warning, matching the
+existing `LINE`-field-on-`POI` convention (`loadConfigStillLoadsAPOIGroupWithLineWidthAndLineColorSet`).
+`ConfigProviderTest` gained `loadConfigStillLoadsAPOIGroupWithFillColorSet`,
+`loadConfigStillLoadsALineGroupWithFillColorSet`, and `loadConfigStillLoadsAShapeGroupWithIconAndOffsetsSet`. See
+ticket 01's Comments for the full implementation summary.

--- a/.scratch/shape-markers/issues/04-shape-readme-docs.md
+++ b/.scratch/shape-markers/issues/04-shape-readme-docs.md
@@ -1,0 +1,25 @@
+# 04 — Docs: README config reference for SHAPE
+
+**What to build:** A server admin reading `README.md` can find `SHAPE` documented as a valid marker group `type`,
+understand the `fillColor` field and the widened `lineWidth`/`lineColor` scope, and copy a working example config
+block for a `SHAPE` group — the same level of documentation `LINE` groups already have.
+
+See `.scratch/shape-markers/spec.md` for full context.
+
+**Blocked by:** 01, 02, 03 — docs should describe the feature's final, complete behavior.
+
+**Status:** resolved
+
+- [x] `README.md`'s config reference lists `SHAPE` as a valid `type` value alongside `POI`/`LINE`.
+- [x] `README.md` documents `fillColor` (format, default, `SHAPE`-only scope) next to the existing
+      `lineWidth`/`lineColor` documentation, and updates `lineWidth`/`lineColor`'s documented scope from "`LINE`
+      only" to "`LINE`/`SHAPE` only".
+- [x] `README.md` includes an example `SHAPE` group config block, alongside the existing `LINE` example.
+
+## Comments
+
+Completed as a side effect of ticket 01, since the underlying feature (and tickets 02/03's transition/warning
+behavior it needed to describe accurately) was already done. Added `SHAPE` to the `type` list, a `fillColor` row,
+widened `lineWidth`/`lineColor`'s documented scope to `LINE`/`SHAPE`, generalized the mismatch-warning paragraph
+beyond just `POI`↔`LINE`, and added a `[region]`/`SHAPE` example group block plus a matching sentence in the
+walkthrough paragraph. See ticket 01's Comments for the full implementation summary.

--- a/.scratch/shape-markers/spec.md
+++ b/.scratch/shape-markers/spec.md
@@ -54,8 +54,9 @@ removing any member sign updates or removes the shape the same way editing a `LI
     in a walk around the region's perimeter produces the polygon I expect (and placing them out of order produces a
     self-intersecting shape I can fix by re-placing/editing signs) — the same placement-order contract `LINE`
     already has.
-14. As a player, I want the shape's rendered height (Y) to be the height of whichever member sign was placed first,
-    so that the polygon sits at one consistent, predictable Y even though member signs may be at different heights.
+14. As a player, I want the shape's rendered height (Y) to be the height of whichever member sign is tallest,
+    so that the polygon sits at one consistent Y that clears every member sign's build, even though member signs
+    may be at different heights.
 15. As a player, I want the shape's detail popup to show the members' shared label text, so that hovering/clicking
     the polygon tells me what it represents (matching `LINE`'s current detail behavior).
 16. As a server admin, I want persisted sign data and existing region-sharded storage/versioning to require no
@@ -77,8 +78,8 @@ removing any member sign updates or removes the shape the same way editing a `LI
   forward; see ADR `0001-shape-points-insertion-order-no-validation`.
 - **Geometry**: a flat BlueMap `ShapeMarker` (2D polygon, single Y for the whole shape, with a border and a fill) —
   not an extruded 3D volume.
-- **Shape Y height**: taken from the oldest (first-placed, lowest `createdAtMillis`) member — the same sign that
-  anchors point order.
+- **Shape Y height**: taken from the tallest member (maximum Y across all current members), recomputed on every
+  join/leave/recompute — independent of placement order/point order, which is still by `createdAtMillis`.
 - **Marker detail**: the shape's detail popup shows the members' shared label text (same value used for the label),
   mirroring `LINE`'s current `createSetLineAction`-style behavior of passing the label as both label and detail.
 - **Config fields on `MarkerGroup`**:

--- a/.scratch/shape-markers/spec.md
+++ b/.scratch/shape-markers/spec.md
@@ -1,0 +1,160 @@
+# Shape (polygon) markers
+
+Status: ready-for-agent
+
+GH issue: https://github.com/tpwalke2/BlueMapSignMarkers/issues/8
+
+## Problem Statement
+
+Players can already mark a single point (`POI`) or a path (`LINE`) on the BlueMap map by placing prefixed signs.
+There's no way to highlight a bounded region — a claim, a district, a farm's territory — without placing a `LINE`
+around its border that doesn't actually enclose or fill anything.
+
+## Solution
+
+A third marker group type, `SHAPE`, works like `LINE` (signs sharing a group's prefix and label become one marker,
+recomputed as members are added/removed) but renders a closed, filled polygon instead of an open path. Placing 3+
+signs with the same `SHAPE`-group prefix and label text draws a filled polygon connecting them; editing, moving, or
+removing any member sign updates or removes the shape the same way editing a `LINE` member does today.
+
+## User Stories
+
+1. As a server admin, I want to define a `SHAPE`-type marker group in `BMSM-Core.json`, so that I can let players
+   mark out regions the same way `POI`/`LINE` groups already let them mark points/paths.
+2. As a player, I want to place 3 or more signs with the same `SHAPE` group's prefix and identical label text, so
+   that a filled polygon marker appears on the map once the third sign is placed.
+3. As a player, I want the polygon to disappear once membership drops back to 2 or fewer signs, so that a shape I'm
+   dismantling doesn't leave a stale marker behind.
+4. As a player, I want editing any one member sign's text (while keeping the same prefix/label) to update the
+   shape's detail popup without breaking or duplicating the marker, so that in-place edits behave the same as they
+   do for `POI`/`LINE`.
+5. As a player, I want to change a member sign's label (splitting it off into a different shape or a plain `POI`),
+   so that the polygon recomputes to exclude that point (or disappears if that drops membership below 3), and no
+   orphaned marker is left under the old id.
+6. As a player, I want to change a sign's prefix so it moves from a `POI`/`LINE` group into a `SHAPE` group (or vice
+   versa), so that the old marker is removed and the new one appears, with no duplicate or leftover marker in
+   BlueMap's UI.
+7. As a server admin, I want an edited `SHAPE` group's `type` flip (e.g. `SHAPE` → `LINE`) to take effect on
+   `/bluemap reload` without a server restart, and without leaving the old shape/line marker behind — matching how
+   `POI`↔`LINE` type flips already self-heal on reload.
+8. As a server admin, I want to configure a `SHAPE` group's `fillColor` (hex, with alpha) independently of its
+   `lineColor`/`lineWidth` border styling, so that I can make a shape's interior translucent while its border stays
+   opaque (or vice versa).
+9. As a server admin, I want `lineWidth`/`lineColor` to be valid fields on both `LINE` and `SHAPE` groups (not just
+   `LINE`), so that I don't have to duplicate border-styling config between the two multi-point group types.
+10. As a server admin, I want a sane default `fillColor` (translucent, not opaque) when I don't set one, so that a
+    `SHAPE` group I configure without styling doesn't blot out the map underneath it.
+11. As a server admin, I want a malformed `fillColor`/`lineColor`/`lineWidth` value in config to fall back to its
+    default and log a warning rather than crash the server or fail to load, matching existing `LINE` field
+    validation behavior.
+12. As a server admin, I want to see a warning (not a crash) if I set a `POI`/`LINE`-only field (`icon`,
+    `offsetX`/`offsetY`) on a `SHAPE` group, or set `fillColor` on a `POI`/`LINE` group, so that misconfiguration is
+    visible without breaking the server.
+13. As a player, I want the shape's points to reflect the order I placed the member signs in, so that placing signs
+    in a walk around the region's perimeter produces the polygon I expect (and placing them out of order produces a
+    self-intersecting shape I can fix by re-placing/editing signs) — the same placement-order contract `LINE`
+    already has.
+14. As a player, I want the shape's rendered height (Y) to be the height of whichever member sign was placed first,
+    so that the polygon sits at one consistent, predictable Y even though member signs may be at different heights.
+15. As a player, I want the shape's detail popup to show the members' shared label text, so that hovering/clicking
+    the polygon tells me what it represents (matching `LINE`'s current detail behavior).
+16. As a server admin, I want persisted sign data and existing region-sharded storage/versioning to require no
+    changes for this feature, so that upgrading to a version with `SHAPE` support doesn't require a migration.
+17. As a developer, I want `SHAPE`'s group-membership resolution, join/leave/recompute logic, and marker-action
+    construction tested at the same seams `LINE`'s equivalents already are, so that the transition table and
+    supporting pure functions have direct unit coverage without needing a live BlueMap/Minecraft environment.
+
+## Implementation Decisions
+
+- **New `MarkerGroupType.SHAPE`** value, alongside existing `POI`/`LINE`.
+- **Membership rule**: identical to `LINE` — all signs sharing a `SHAPE` group's prefix and the same label text
+  (post-prefix-strip) are members of one shape; that `(prefix, label)` pair is the shape's identity.
+- **Render threshold**: a shape marker is created once 3+ members exist (vs. `LINE`'s 2), and removed once
+  membership drops back to 2 or fewer. `isFirstAppearance` (log-only, mirrors `LINE`'s convention) is true the first
+  time membership reaches exactly 3.
+- **Point order**: members ordered by `createdAtMillis` (placement time), same as `LineGroupResolver.members` — no
+  spatial sorting, no self-intersection/degeneracy validation. This carries `LINE`'s existing documented limitation
+  forward; see ADR `0001-shape-points-insertion-order-no-validation`.
+- **Geometry**: a flat BlueMap `ShapeMarker` (2D polygon, single Y for the whole shape, with a border and a fill) —
+  not an extruded 3D volume.
+- **Shape Y height**: taken from the oldest (first-placed, lowest `createdAtMillis`) member — the same sign that
+  anchors point order.
+- **Marker detail**: the shape's detail popup shows the members' shared label text (same value used for the label),
+  mirroring `LINE`'s current `createSetLineAction`-style behavior of passing the label as both label and detail.
+- **Config fields on `MarkerGroup`**:
+  - `lineWidth`/`lineColor` scope widens from "`LINE` only" to "`LINE`/`SHAPE` only" (border styling, reused as-is).
+  - New `fillColor` field (`SHAPE`-only), same hex-with-optional-alpha string format as `lineColor`
+    (`ColorUtils.parseHex`/`isValidHex`, unchanged — no new parsing logic needed).
+  - Default `fillColor` when unset: a translucent value (e.g. `#FF000033`) rather than `LINE`'s opaque
+    `#FF0000FF` default — a highlighted region should default to not obscuring the map.
+  - Field-mismatch warnings (`ConfigProvider`) extend to cover `SHAPE`: `icon`/`offsetX`/`offsetY` set on a `SHAPE`
+    group warn-and-ignore (same as they already do for `LINE`); `fillColor` set on a `POI`/`LINE` group warns and is
+    ignored; malformed `fillColor`/`lineWidth`/`lineColor` on a `SHAPE` group falls back to its default and logs a
+    warning (same pattern as existing `resolveLineWidth`/`resolveLineColor`).
+- **New types mirroring `LINE`'s existing structure** (duplicated pattern, not a generic abstraction — see ADR
+  `0002-shape-duplicates-line-pattern`):
+  - `ShapeGroupResolver.members(...)` — same shape as `LineGroupResolver.members`.
+  - `SetShapeMarkerAction` / `RemoveShapeMarkerAction` — mirror `SetLineMarkerAction`/`RemoveLineMarkerAction`;
+    `SetShapeMarkerAction` carries label, detail, ordered points, `fillColor`, `lineWidth`, `lineColor`, and the
+    log-only `isFirstAppearance` flag.
+  - `ShapeMarkerIdentifier` — mirrors `LineMarkerIdentifier`, id scheme `"shape:" + label`.
+  - `ActionFactory.createSetShapeAction(...)` / `createRemoveShapeAction(...)` — mirror the `Line` equivalents.
+  - Where the resulting logic is genuinely identical between `LINE` and `SHAPE` (e.g. the join/leave/threshold
+    recompute shape), factor it into shared pure functions rather than copy-pasting, without introducing a generic
+    "multi-point group" type.
+- **`SignTransitionResolver.computeTransitionAction`**: extend the type-pair branching (currently `POI`/`LINE`
+  only) to a 3-way switch covering every `POI`/`LINE`/`SHAPE` combination, including `SHAPE`↔`SHAPE` same-group
+  recompute (mirroring the existing `LINE`↔`LINE` branch) and `SHAPE` join/leave helpers (mirroring
+  `lineJoinAction`/`lineLeaveAction`) used both for live sign edits and the `/bluemap reload` self-heal path.
+- **`BlueMapAPIConnector`**: add a `case SetShapeMarkerAction` / `case RemoveShapeMarkerAction` arm to both
+  `processMarkerAction`'s switch and `logProcessingMessage`'s switch (required per `AGENTS.md` — `MarkerAction` is
+  an unsealed abstract class, so a missing case silently falls into `default` instead of failing to compile);
+  `setShapeMarker` builds a `de.bluecolored.bluemap.api.markers.ShapeMarker` from the ordered points (x/z only,
+  BlueMap's `Shape` type), the anchor Y, `fillColor`, `lineWidth`, and `lineColor`.
+- **No persistence/schema changes**: `SHAPE` groups use the same `SignEntry`/region-sharded storage as `POI`/`LINE`
+  today; no new sign-persistence field or `SignFileVersions` bump is needed.
+- **Docs**: `README.md`'s config reference gains `SHAPE` as a valid `type`, documents `fillColor` (and the widened
+  `lineWidth`/`lineColor` scope), and an example `SHAPE` group block alongside the existing `LINE` example.
+
+## Testing Decisions
+
+Good tests here exercise externally-observable behavior (given a set of signs/config, what marker action comes
+out) rather than internal wiring — same standard the existing `LINE` tests already hold to. Four seams, matching
+the ones already established for `LINE` (no new seams introduced):
+
+- **`SignTransitionResolverTest`** (primary seam) — table-driven, one test per new branch/sub-case: `SHAPE` join at
+  membership 1→2 (no-op, below threshold), 2→3 (first appearance), 3→4+ (recompute); `SHAPE` leave at 4→3
+  (recompute), 3→2 (remove), 2→1/1→0 (no-op); `SHAPE`↔`SHAPE` same-group detail-only edit; every `POI`↔`SHAPE` and
+  `LINE`↔`SHAPE` type-flip pair (both directions), including the `isReload` variants exercised by the existing
+  `LINE`/`POI` reload tests.
+- **`ShapeGroupResolverTest`** — new file mirroring `LineGroupResolverTest`: filters by parent map, prefix, and
+  label; orders by `createdAtMillis`.
+- **`ActionFactoryTest`** — extend with `createSetShapeAction`/`createRemoveShapeAction` construction cases
+  (correct id scheme, correct field passthrough), mirroring the existing `createSetLineAction`/
+  `createRemoveLineAction` cases.
+- **`ConfigProviderTest`** — extend with `SHAPE` field resolution/defaulting: `fillColor` default and malformed-hex
+  fallback (mirroring `resolveLineColor`'s existing test cases), `lineWidth`/`lineColor` now valid (no warning) on
+  `SHAPE`, and the new `fillColor`-on-`POI`/`LINE` and `icon`/`offsetX`/`offsetY`-on-`SHAPE` mismatch warnings.
+
+No new tests needed for `ColorUtils` (already generically covered by `ColorUtilsTest`) or `BlueMapAPIConnector`
+(game-coupled, verified manually via `runServer` per `AGENTS.md`, same as `LINE`'s `setLineMarker`).
+
+## Out of Scope
+
+- Extruded/3D volume shapes (BlueMap's `ExtrudeMarker`) — flat `ShapeMarker` only.
+- Spatial point ordering, convexity enforcement, or self-intersection detection/warnings.
+- Per-member detail aggregation (richer shape detail text beyond the shared label) — this would be a separate
+  enhancement, applicable to `LINE` too if ever wanted.
+- A generic "multi-point marker group" abstraction shared between `LINE` and `SHAPE`.
+- Any sign-persistence schema change or migration.
+- Manual/in-game verification of the `BlueMapAPIConnector` rendering path (tracked as a manual `runServer` check
+  per `AGENTS.md`'s testable-vs-game-coupled split, not part of this spec's automated test scope).
+
+## Further Notes
+
+- ADRs recorded during design: `docs/adr/0001-shape-points-insertion-order-no-validation.md`,
+  `docs/adr/0002-shape-duplicates-line-pattern.md`.
+- Glossary terms (`Shape`, `Label`, `Representation`) recorded in `CONTEXT.md`.
+- Original GH issue (#8, title `[area] builds area markersets`) had no body — the "area" language in its title was
+  deliberately renamed to `SHAPE` in code/config/docs to match BlueMap's own marker naming and to distinguish the
+  concrete geometric object (a polygon) from the vaguer goal it achieves (highlighting an area).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,27 @@
+# Context
+
+Glossary for BlueMap Sign Markers. See `AGENTS.md` for architecture; this file is vocabulary only.
+
+## Terms
+
+**Marker group** — a configured `(prefix, matchType, type, ...)` rule (`MarkerGroup`) that turns matching sign text
+into a marker. `type` (`MarkerGroupType`) picks the shape: `POI`, `LINE`, or `SHAPE`.
+
+**POI marker** — a single-sign point marker. One sign, one marker.
+
+**Line** — a multi-sign marker built from every sign sharing a `LINE` group's prefix and the same label text (that
+shared `(prefix, label)` pair is the line's membership key). Renders once 2+ members exist; points are ordered by
+placement time (`createdAtMillis`), not spatial position.
+
+**Shape** — a multi-sign marker built the same way as a Line (shared `(prefix, label)` membership key, points
+ordered by placement time), but rendered as a flat, closed BlueMap `ShapeMarker` (2D polygon at one Y height, with a
+fill) instead of an open 3D line. Renders once 3+ members exist — a 2-point "polygon" is degenerate. The shape's Y
+height is taken from its oldest (first-placed) member, the same sign that anchors point order. A Shape's detail
+popup shows the members' shared label text, same as a Line's.
+
+**Label** — the sign text after a group's prefix is stripped. For `LINE`/`SHAPE` groups, label equality (within the
+same prefix) is what makes two signs members of the same line/shape.
+
+**Representation** — a sign's computed `(group, label, detail)` under the current config, or `null` if no group
+matches its prefix (`SignTransitionResolver.Representation`). Comparing a sign's old vs. new representation is how
+the mod decides what marker action to dispatch on any change (edit, removal, or a `/bluemap reload` config swap).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,8 +16,9 @@ placement time (`createdAtMillis`), not spatial position.
 **Shape** — a multi-sign marker built the same way as a Line (shared `(prefix, label)` membership key, points
 ordered by placement time), but rendered as a flat, closed BlueMap `ShapeMarker` (2D polygon at one Y height, with a
 fill) instead of an open 3D line. Renders once 3+ members exist — a 2-point "polygon" is degenerate. The shape's Y
-height is taken from its oldest (first-placed) member, the same sign that anchors point order. A Shape's detail
-popup shows the members' shared label text, same as a Line's.
+height is taken from its tallest member (max Y across all current members), recomputed on every join/leave/recompute
+— independent of point order, which stays placement-time-based. A Shape's detail popup shows the members' shared
+label text, same as a Line's.
 
 **Label** — the sign text after a group's prefix is stripped. For `LINE`/`SHAPE` groups, label equality (within the
 same prefix) is what makes two signs members of the same line/shape.

--- a/README.md
+++ b/README.md
@@ -37,17 +37,19 @@ configuration contains the following options:
 - `type` - the type of marker to display; optional; default is `POI`
   - `POI` - a single point marker per sign;
   - `LINE` - signs sharing this group's prefix and the same first-line label become ordered points of one line marker (points ordered by placement time); requires at least 2 signs to appear;
+  - `SHAPE` - signs sharing this group's prefix and the same first-line label become ordered points of one filled polygon marker (points ordered by placement time, height taken from the first-placed sign); requires at least 3 signs to appear;
 - `icon` - the icon path or URL to display for the marker; optional; default is `null` (BlueMap default POI icon); `POI` only
 - `offsetX` - the x offset of the marker; optional; default is `0` (corresponds with `anchor.x` in BlueMap base configuration); `POI` only
 - `offsetY` - the y offset of the marker; optional; default is `0` (corresponds with `anchor.y` in BlueMap base configuration); `POI` only
 - `defaultHidden` - If this is true, the marker-set will be hidden by default and can be enabled by the user; optional; default is `false`
 - `minDistance` - the minimum distance from the camera at which the marker will be displayed; optional; default is `0.0` (floating point, double precision)
 - `maxDistance` - the maximum distance from the camera at which the marker will be displayed; optional; default is `10000000.0` (floating point, double precision)
-- `lineWidth` - the width in pixels of the line; optional; default is `2`; `LINE` only
-- `lineColor` - the hex color (with alpha) of the line, e.g. `#FF0000FF`; optional; default is `#FF0000FF`; `LINE` only
+- `lineWidth` - the width in pixels of the line/shape border; optional; default is `2`; `LINE`/`SHAPE` only
+- `lineColor` - the hex color (with alpha) of the line/shape border, e.g. `#FF0000FF`; optional; default is `#FF0000FF`; `LINE`/`SHAPE` only
+- `fillColor` - the hex color (with alpha) of a shape's interior, e.g. `#FF000033`; optional; default is `#FF000033` (translucent red); `SHAPE` only
 
-Setting a `POI`-only field on a `LINE` group (or vice versa) is not an error; the mod logs a warning and ignores the
-field.
+Setting a field on a group type it doesn't apply to (e.g. `icon` on a `LINE`/`SHAPE` group, or `fillColor` on a
+`POI`/`LINE` group) is not an error; the mod logs a warning and ignores the field.
 
 ## Example
 
@@ -74,13 +76,22 @@ field.
       "type": "LINE",
       "lineWidth": 3,
       "lineColor": "#00A2FFFF"
+    },
+    {
+      "prefix": "[region]",
+      "name": "Regions",
+      "type": "SHAPE",
+      "lineWidth": 2,
+      "lineColor": "#FFA500FF",
+      "fillColor": "#FFA50040"
     }
   ]
 }
 ```
 
-This example configuration creates 4 marker groups: one for `[poi]` signs, one for `[store]` signs, one for signs
-where the prefix is a regex match for villages (e.g. `[Village]` or `[VILLAGE]`), and one for `[trail]` signs.
+This example configuration creates 5 marker groups: one for `[poi]` signs, one for `[store]` signs, one for signs
+where the prefix is a regex match for villages (e.g. `[Village]` or `[VILLAGE]`), one for `[trail]` signs, and one
+for `[region]` signs.
 
 ## Troubleshooting
 
@@ -96,5 +107,7 @@ located at `assets/store.png`.
 Signs with the `[poi]` prefix will be displayed in the "Points of Interest" marker group. Signs with the `[store]`
 prefix will be displayed in the "Stores" marker group. Signs that match the villages regex will be displayed in the
 'Villages' marker group. Signs with the `[trail]` prefix, sharing the same description line, will be connected in
-placement order into a line in the "Trails" marker group once 2 or more such signs exist.
+placement order into a line in the "Trails" marker group once 2 or more such signs exist. Signs with the `[region]`
+prefix, sharing the same description line, will be connected in placement order into a filled polygon in the
+"Regions" marker group once 3 or more such signs exist.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ configuration contains the following options:
 - `type` - the type of marker to display; optional; default is `POI`
   - `POI` - a single point marker per sign;
   - `LINE` - signs sharing this group's prefix and the same first-line label become ordered points of one line marker (points ordered by placement time); requires at least 2 signs to appear;
-  - `SHAPE` - signs sharing this group's prefix and the same first-line label become ordered points of one filled polygon marker (points ordered by placement time, height taken from the first-placed sign); requires at least 3 signs to appear;
+  - `SHAPE` - signs sharing this group's prefix and the same first-line label become ordered points of one filled polygon marker (points ordered by placement time, height taken from the tallest member); requires at least 3 signs to appear;
 - `icon` - the icon path or URL to display for the marker; optional; default is `null` (BlueMap default POI icon); `POI` only
 - `offsetX` - the x offset of the marker; optional; default is `0` (corresponds with `anchor.x` in BlueMap base configuration); `POI` only
 - `offsetY` - the y offset of the marker; optional; default is `0` (corresponds with `anchor.y` in BlueMap base configuration); `POI` only

--- a/docs/adr/0001-shape-points-insertion-order-no-validation.md
+++ b/docs/adr/0001-shape-points-insertion-order-no-validation.md
@@ -1,0 +1,9 @@
+# Shape marker points follow insertion order, with no geometry validation
+
+`SHAPE` groups (polygon markers built from signs sharing a prefix and label) order their points by
+`createdAtMillis` — placement time, not spatial position — and never validate the resulting polygon for
+self-intersection or zero-area collinear points. We considered spatially sorting points (e.g. by angle around a
+centroid) or rejecting/warning on a degenerate shape, but chose insertion order + no validation to stay consistent
+with the existing `LINE` group's contract, which already accepts placement-order zigzags as a known limitation. A
+bowtie or sliver shape is possible if signs aren't placed in a sensible perimeter walk; the placer is expected to
+notice and fix it in-game, the same way a bad `LINE` is fixed today.

--- a/docs/adr/0002-shape-duplicates-line-pattern.md
+++ b/docs/adr/0002-shape-duplicates-line-pattern.md
@@ -1,0 +1,12 @@
+# SHAPE duplicates LINE's group-resolver/action pattern instead of a generic abstraction
+
+`SHAPE` groups are structurally identical to `LINE` groups: N signs sharing a `(prefix, label)` key, ordered by
+placement time, recomputed on any member change, rendered once a threshold is met. This is the second concrete
+instance of that pattern, so extracting a generic "multi-point group" mechanism (parameterized by marker kind and
+threshold) was a real option. We chose to duplicate `LINE`'s pattern instead — new `ShapeGroupResolver`,
+`SetShapeMarkerAction`/`RemoveShapeMarkerAction`, `ShapeMarkerIdentifier`, and a 3-way switch in
+`SignTransitionResolver` — because that resolver's transition table is dense branch-per-type-pair logic already
+tuned around two types, and forcing a third through a generic abstraction risked making it harder to read for a
+marginal reuse win. Genuinely-identical inline logic (member resolution, join/leave/threshold math) was factored
+into shared pure functions where duplication would otherwise be copy-paste, short of a full generic type. Revisit
+extraction if a fourth multi-point marker kind appears.

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ loader_version=0.19.3
 # Mod Properties
 mod_id=bluemapsignmarkers
 mod_name=BlueMap Sign Markers
-mod_version=26.2-0.20.0
+mod_version=26.2-0.21.0
 mod_description=A plugin for BlueMap that creates markers from signs
 maven_group=com.tpwalke2.bluemapsignmarkers
 archives_base_name=bluemapsignmarkers

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProvider.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProvider.java
@@ -176,6 +176,9 @@ public class ConfigProvider {
                 if (markerGroup.lineColor() != null) {
                     LOGGER.warn("Marker group '{}' is type POI but has 'lineColor' set; this field is ignored for POI groups", name);
                 }
+                if (markerGroup.fillColor() != null) {
+                    LOGGER.warn("Marker group '{}' is type POI but has 'fillColor' set; this field is ignored for POI groups", name);
+                }
             } else if (type == MarkerGroupType.LINE) {
                 if (markerGroup.icon() != null) {
                     LOGGER.warn("Marker group '{}' is type LINE but has 'icon' set; this field is ignored for LINE groups", name);
@@ -185,6 +188,19 @@ public class ConfigProvider {
                 }
                 if (markerGroup.offsetY() != null) {
                     LOGGER.warn("Marker group '{}' is type LINE but has 'offsetY' set; this field is ignored for LINE groups", name);
+                }
+                if (markerGroup.fillColor() != null) {
+                    LOGGER.warn("Marker group '{}' is type LINE but has 'fillColor' set; this field is ignored for LINE groups", name);
+                }
+            } else if (type == MarkerGroupType.SHAPE) {
+                if (markerGroup.icon() != null) {
+                    LOGGER.warn("Marker group '{}' is type SHAPE but has 'icon' set; this field is ignored for SHAPE groups", name);
+                }
+                if (markerGroup.offsetX() != null) {
+                    LOGGER.warn("Marker group '{}' is type SHAPE but has 'offsetX' set; this field is ignored for SHAPE groups", name);
+                }
+                if (markerGroup.offsetY() != null) {
+                    LOGGER.warn("Marker group '{}' is type SHAPE but has 'offsetY' set; this field is ignored for SHAPE groups", name);
                 }
             }
         }
@@ -205,20 +221,21 @@ public class ConfigProvider {
                 markerGroup.minDistance() == null ? 0.0 : markerGroup.minDistance(),
                 markerGroup.maxDistance() == null ? 10000000.0 : markerGroup.maxDistance(),
                 resolveLineWidth(markerGroup),
-                resolveLineColor(markerGroup)
+                resolveLineColor(markerGroup),
+                resolveFillColor(markerGroup)
         );
     }
 
     // Falls back to the default width on a non-positive value rather than throwing - a bad config value
     // must not crash the server (same treatment as ColorUtils.parseHex's fallback on a malformed color).
-    // Only validated for LINE groups - lineWidth is ignored for POI groups (warnOnTypeFieldMismatches already
-    // warns about it being set), so validating it here too would just be a second, confusing warning.
+    // Only validated for LINE/SHAPE groups - lineWidth is ignored for POI groups (warnOnTypeFieldMismatches
+    // already warns about it being set), so validating it here too would just be a second, confusing warning.
     private static int resolveLineWidth(LoadingMarkerGroupV2 markerGroup) {
         var lineWidth = markerGroup.lineWidth();
         if (lineWidth == null) return DEFAULT_LINE_WIDTH;
 
         var type = effectiveType(markerGroup);
-        if (type != MarkerGroupType.LINE) return lineWidth;
+        if (type != MarkerGroupType.LINE && type != MarkerGroupType.SHAPE) return lineWidth;
 
         if (lineWidth <= 0) {
             LOGGER.warn("Marker group '{}' has a non-positive 'lineWidth' ({}); falling back to default {}",
@@ -231,7 +248,7 @@ public class ConfigProvider {
 
     // Warns and falls back to the default color at load time (rather than silently at dispatch time via
     // ColorUtils.parseHex's fallback) so a malformed color gets a clear, attributable log message.
-    // Only validated for LINE groups - see resolveLineWidth above.
+    // Only validated for LINE/SHAPE groups - see resolveLineWidth above.
     private static final String DEFAULT_LINE_COLOR = "#FF0000FF";
 
     private static String resolveLineColor(LoadingMarkerGroupV2 markerGroup) {
@@ -239,7 +256,7 @@ public class ConfigProvider {
         if (lineColor == null) return DEFAULT_LINE_COLOR;
 
         var type = effectiveType(markerGroup);
-        if (type != MarkerGroupType.LINE) return lineColor;
+        if (type != MarkerGroupType.LINE && type != MarkerGroupType.SHAPE) return lineColor;
 
         if (!ColorUtils.isValidHex(lineColor)) {
             LOGGER.warn("Marker group '{}' has a malformed 'lineColor' ({}); falling back to default {}",
@@ -248,6 +265,27 @@ public class ConfigProvider {
         }
 
         return lineColor;
+    }
+
+    // fillColor is SHAPE-only; its default is translucent (unlike lineColor's opaque default) so a SHAPE
+    // group configured without styling doesn't blot out the map underneath it. Only validated for SHAPE
+    // groups - see resolveLineWidth above.
+    private static final String DEFAULT_FILL_COLOR = "#FF000033";
+
+    private static String resolveFillColor(LoadingMarkerGroupV2 markerGroup) {
+        var fillColor = markerGroup.fillColor();
+        if (fillColor == null) return DEFAULT_FILL_COLOR;
+
+        var type = effectiveType(markerGroup);
+        if (type != MarkerGroupType.SHAPE) return fillColor;
+
+        if (!ColorUtils.isValidHex(fillColor)) {
+            LOGGER.warn("Marker group '{}' has a malformed 'fillColor' ({}); falling back to default {}",
+                    markerGroup.name(), fillColor, DEFAULT_FILL_COLOR);
+            return DEFAULT_FILL_COLOR;
+        }
+
+        return fillColor;
     }
 
     private static BMSMConfigV2 loadV1Config(File file, BMSMConfigV1 v1Config) {
@@ -272,6 +310,7 @@ public class ConfigProvider {
                         0,
                         10000000.0,
                         2,
-                        "#FF0000FF"));
+                        "#FF0000FF",
+                        "#FF000033"));
     }
 }

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/config/persistence/LoadingBMSMConfigV2.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/config/persistence/LoadingBMSMConfigV2.java
@@ -30,7 +30,8 @@ public final class LoadingBMSMConfigV2 {
                 defaultGroup.minDistance(),
                 defaultGroup.maxDistance(),
                 defaultGroup.lineWidth(),
-                defaultGroup.lineColor());
+                defaultGroup.lineColor(),
+                defaultGroup.fillColor());
     }
 
     public LoadingMarkerGroupV2[] getMarkerGroups() {

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/config/persistence/LoadingMarkerGroupV2.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/config/persistence/LoadingMarkerGroupV2.java
@@ -15,5 +15,6 @@ public record LoadingMarkerGroupV2(
         Double minDistance,
         Double maxDistance,
         Integer lineWidth,
-        String lineColor) {
+        String lineColor,
+        String fillColor) {
 }

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
@@ -217,7 +217,7 @@ public class BlueMapAPIConnector {
             position = String.format(" label='%s'", LogUtils.sanitizeForLog(shapeMarkerIdentifier.label()));
         }
 
-        LOGGER.info("{} {} type marker in {}{}{}",
+        LOGGER.debug("{} {} type marker in {}{}{}",
                 operation,
                 identifier.parentSet().markerGroup().type(),
                 identifier.parentSet().mapId(),

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
@@ -16,6 +16,7 @@ import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.SetShapeMarkerAction
 import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.UpdateMarkerAction;
 import com.tpwalke2.bluemapsignmarkers.core.markers.DispatchedMarkerIdentifier;
 import com.tpwalke2.bluemapsignmarkers.core.markers.LineMarkerIdentifier;
+import com.tpwalke2.bluemapsignmarkers.core.markers.LinePoint;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupType;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerIdentifier;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerSetIdentifier;
@@ -246,6 +247,16 @@ public class BlueMapAPIConnector {
         markerSetMaps.forEach(stringMarkerMap -> stringMarkerMap.remove(id));
     }
 
+    // ColorUtils.parseHex returns alpha in the same 0-255 range as r/g/b, but BlueMap's Color(int, int, int,
+    // float) constructor takes alpha in 0-1 - passing the raw 0-255 int straight through (as the earlier
+    // Color(int, int, int, int alpha-as-int) overload does, treating alpha/255f) is NOT what an int
+    // widening to float gives you: it silently widens to e.g. 51.0f instead of dividing by 255, which
+    // BlueMap then clamps to fully opaque. Every translucent color (e.g. SHAPE's fillColor default) rendered
+    // fully opaque as a result.
+    private static Color toBlueMapColor(int[] rgba) {
+        return new Color(rgba[0], rgba[1], rgba[2], rgba[3] / 255f);
+    }
+
     private static void setLineMarker(SetLineMarkerAction action, Stream<Map<String, Marker>> markerSetMaps) {
         LOGGER.debug("Setting line marker...");
         if (action.getPoints().size() < 2) return; // defensive - SignManager should never dispatch below 2
@@ -260,7 +271,7 @@ public class BlueMapAPIConnector {
                     .detail(HtmlUtils.toHtmlDetail(action.getDetail()))
                     .line(line)
                     .lineWidth(action.getLineWidth())
-                    .lineColor(new Color(color[0], color[1], color[2], color[3]))
+                    .lineColor(toBlueMapColor(color))
                     .build();
             marker.setMinDistance(markerGroup.minDistance());
             marker.setMaxDistance(markerGroup.maxDistance());
@@ -274,7 +285,9 @@ public class BlueMapAPIConnector {
 
         var points = action.getPoints();
         var shape = new Shape(points.stream().map(p -> new Vector2d(p.x(), p.z())).toList());
-        var shapeY = points.get(0).y(); // oldest (first-placed) member anchors the shape's height
+        // Shape height anchors to the tallest member rather than placement order, so the polygon always
+        // clears the terrain/builds of every sign that defines it.
+        var shapeY = (float) points.stream().mapToInt(LinePoint::y).max().orElseThrow();
         var lineColor = ColorUtils.parseHex(action.getLineColor());
         var fillColor = ColorUtils.parseHex(action.getFillColor());
         var markerGroup = action.getMarkerIdentifier().parentSet().markerGroup();
@@ -285,8 +298,8 @@ public class BlueMapAPIConnector {
                     .detail(HtmlUtils.toHtmlDetail(action.getDetail()))
                     .shape(shape, shapeY)
                     .lineWidth(action.getLineWidth())
-                    .lineColor(new Color(lineColor[0], lineColor[1], lineColor[2], lineColor[3]))
-                    .fillColor(new Color(fillColor[0], fillColor[1], fillColor[2], fillColor[3]))
+                    .lineColor(toBlueMapColor(lineColor))
+                    .fillColor(toBlueMapColor(fillColor))
                     .build();
             marker.setMinDistance(markerGroup.minDistance());
             marker.setMaxDistance(markerGroup.maxDistance());

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
@@ -10,22 +10,28 @@ import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.GroupTransitionMarke
 import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.MarkerAction;
 import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.RemoveLineMarkerAction;
 import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.RemoveMarkerAction;
+import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.RemoveShapeMarkerAction;
 import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.SetLineMarkerAction;
+import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.SetShapeMarkerAction;
 import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.UpdateMarkerAction;
 import com.tpwalke2.bluemapsignmarkers.core.markers.DispatchedMarkerIdentifier;
 import com.tpwalke2.bluemapsignmarkers.core.markers.LineMarkerIdentifier;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupType;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerIdentifier;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerSetIdentifier;
+import com.tpwalke2.bluemapsignmarkers.core.markers.ShapeMarkerIdentifier;
 import com.tpwalke2.bluemapsignmarkers.core.reactive.ReactiveQueue;
+import com.flowpowered.math.vector.Vector2d;
 import de.bluecolored.bluemap.api.BlueMapAPI;
 import de.bluecolored.bluemap.api.BlueMapMap;
 import de.bluecolored.bluemap.api.markers.LineMarker;
 import de.bluecolored.bluemap.api.markers.Marker;
 import de.bluecolored.bluemap.api.markers.MarkerSet;
 import de.bluecolored.bluemap.api.markers.POIMarker;
+import de.bluecolored.bluemap.api.markers.ShapeMarker;
 import de.bluecolored.bluemap.api.math.Color;
 import de.bluecolored.bluemap.api.math.Line;
+import de.bluecolored.bluemap.api.math.Shape;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -157,6 +163,10 @@ public class BlueMapAPIConnector {
                     applyToMarkerSets(setAction.getMarkerIdentifier(), markerSetMaps -> setLineMarker(setAction, markerSetMaps));
             case RemoveLineMarkerAction removeAction ->
                     applyToMarkerSets(removeAction.getMarkerIdentifier(), markerSetMaps -> removeMarkerById(removeAction.getMarkerIdentifier().getId(), markerSetMaps));
+            case SetShapeMarkerAction setAction ->
+                    applyToMarkerSets(setAction.getMarkerIdentifier(), markerSetMaps -> setShapeMarker(setAction, markerSetMaps));
+            case RemoveShapeMarkerAction removeAction ->
+                    applyToMarkerSets(removeAction.getMarkerIdentifier(), markerSetMaps -> removeMarkerById(removeAction.getMarkerIdentifier().getId(), markerSetMaps));
             default -> LOGGER.warn("Unknown marker action: {}", markerAction);
         }
     }
@@ -180,6 +190,8 @@ public class BlueMapAPIConnector {
             case UpdateMarkerAction ignored -> "Updating";
             case RemoveLineMarkerAction ignored -> "Removing";
             case SetLineMarkerAction setAction -> setAction.isFirstAppearance() ? "Adding" : "Updating";
+            case RemoveShapeMarkerAction ignored -> "Removing";
+            case SetShapeMarkerAction setAction -> setAction.isFirstAppearance() ? "Adding" : "Updating";
             default -> "Processing";
         };
 
@@ -198,6 +210,10 @@ public class BlueMapAPIConnector {
             position = String.format(" label='%s' with %d point(s)", LogUtils.sanitizeForLog(setAction.getLabel()), setAction.getPoints().size());
         } else if (identifier instanceof LineMarkerIdentifier lineMarkerIdentifier) {
             position = String.format(" label='%s'", LogUtils.sanitizeForLog(lineMarkerIdentifier.label()));
+        } else if (identifier instanceof ShapeMarkerIdentifier && action instanceof SetShapeMarkerAction setAction) {
+            position = String.format(" label='%s' with %d point(s)", LogUtils.sanitizeForLog(setAction.getLabel()), setAction.getPoints().size());
+        } else if (identifier instanceof ShapeMarkerIdentifier shapeMarkerIdentifier) {
+            position = String.format(" label='%s'", LogUtils.sanitizeForLog(shapeMarkerIdentifier.label()));
         }
 
         LOGGER.info("{} {} type marker in {}{}{}",
@@ -245,6 +261,32 @@ public class BlueMapAPIConnector {
                     .line(line)
                     .lineWidth(action.getLineWidth())
                     .lineColor(new Color(color[0], color[1], color[2], color[3]))
+                    .build();
+            marker.setMinDistance(markerGroup.minDistance());
+            marker.setMaxDistance(markerGroup.maxDistance());
+            markers.put(action.getMarkerIdentifier().getId(), marker);
+        });
+    }
+
+    private static void setShapeMarker(SetShapeMarkerAction action, Stream<Map<String, Marker>> markerSetMaps) {
+        LOGGER.debug("Setting shape marker...");
+        if (action.getPoints().size() < 3) return; // defensive - SignManager should never dispatch below 3
+
+        var points = action.getPoints();
+        var shape = new Shape(points.stream().map(p -> new Vector2d(p.x(), p.z())).toList());
+        var shapeY = points.get(0).y(); // oldest (first-placed) member anchors the shape's height
+        var lineColor = ColorUtils.parseHex(action.getLineColor());
+        var fillColor = ColorUtils.parseHex(action.getFillColor());
+        var markerGroup = action.getMarkerIdentifier().parentSet().markerGroup();
+
+        markerSetMaps.forEach(markers -> {
+            var marker = ShapeMarker.builder()
+                    .label(action.getLabel())
+                    .detail(HtmlUtils.toHtmlDetail(action.getDetail()))
+                    .shape(shape, shapeY)
+                    .lineWidth(action.getLineWidth())
+                    .lineColor(new Color(lineColor[0], lineColor[1], lineColor[2], lineColor[3]))
+                    .fillColor(new Color(fillColor[0], fillColor[1], fillColor[2], fillColor[3]))
                     .build();
             marker.setMinDistance(markerGroup.minDistance());
             marker.setMaxDistance(markerGroup.maxDistance());

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/actions/ActionFactory.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/actions/ActionFactory.java
@@ -5,6 +5,7 @@ import com.tpwalke2.bluemapsignmarkers.core.markers.LinePoint;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroup;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerIdentifier;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerSetIdentifierCollection;
+import com.tpwalke2.bluemapsignmarkers.core.markers.ShapeMarkerIdentifier;
 
 import java.util.List;
 
@@ -92,6 +93,29 @@ public class ActionFactory {
     public RemoveLineMarkerAction createRemoveLineAction(String mapId, MarkerGroup markerGroup, String label) {
         return new RemoveLineMarkerAction(
                 new LineMarkerIdentifier(label, markerSetIdentifierCollection.getIdentifier(mapId, markerGroup)));
+    }
+
+    public SetShapeMarkerAction createSetShapeAction(
+            String mapId,
+            MarkerGroup markerGroup,
+            String label,
+            String detail,
+            List<LinePoint> points,
+            boolean isFirstAppearance) {
+        return new SetShapeMarkerAction(
+                new ShapeMarkerIdentifier(label, markerSetIdentifierCollection.getIdentifier(mapId, markerGroup)),
+                label,
+                detail,
+                points,
+                markerGroup.lineWidth(),
+                markerGroup.lineColor(),
+                markerGroup.fillColor(),
+                isFirstAppearance);
+    }
+
+    public RemoveShapeMarkerAction createRemoveShapeAction(String mapId, MarkerGroup markerGroup, String label) {
+        return new RemoveShapeMarkerAction(
+                new ShapeMarkerIdentifier(label, markerSetIdentifierCollection.getIdentifier(mapId, markerGroup)));
     }
 
     public UpdateMarkerAction createUpdatePOIAction(

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/actions/RemoveShapeMarkerAction.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/actions/RemoveShapeMarkerAction.java
@@ -1,0 +1,16 @@
+package com.tpwalke2.bluemapsignmarkers.core.bluemap.actions;
+
+import com.tpwalke2.bluemapsignmarkers.core.markers.ShapeMarkerIdentifier;
+
+public class RemoveShapeMarkerAction extends MarkerAction {
+    public RemoveShapeMarkerAction(ShapeMarkerIdentifier markerIdentifier) {
+        super(markerIdentifier);
+    }
+
+    @Override
+    public String toString() {
+        return "RemoveShapeMarkerAction{" +
+                "markerIdentifier=" + getMarkerIdentifier() +
+                '}';
+    }
+}

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/actions/SetShapeMarkerAction.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/actions/SetShapeMarkerAction.java
@@ -1,0 +1,80 @@
+package com.tpwalke2.bluemapsignmarkers.core.bluemap.actions;
+
+import com.tpwalke2.bluemapsignmarkers.core.markers.LinePoint;
+import com.tpwalke2.bluemapsignmarkers.core.markers.ShapeMarkerIdentifier;
+
+import java.util.List;
+
+public class SetShapeMarkerAction extends MarkerAction {
+    private final String label;
+    private final String detail;
+    private final List<LinePoint> points;
+    private final int lineWidth;
+    private final String lineColor;
+    private final String fillColor;
+    // Log-only: whether this shape is being created for the first time vs. re-set with an updated point
+    // list. Not a distinct subtype - BlueMap has no separate add/update call for shape markers, so this
+    // only affects the log message, not the BlueMap API call made.
+    private final boolean isFirstAppearance;
+
+    public SetShapeMarkerAction(
+            ShapeMarkerIdentifier markerIdentifier,
+            String label,
+            String detail,
+            List<LinePoint> points,
+            int lineWidth,
+            String lineColor,
+            String fillColor,
+            boolean isFirstAppearance) {
+        super(markerIdentifier);
+        this.label = label;
+        this.detail = detail;
+        this.points = points;
+        this.lineWidth = lineWidth;
+        this.lineColor = lineColor;
+        this.fillColor = fillColor;
+        this.isFirstAppearance = isFirstAppearance;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public List<LinePoint> getPoints() {
+        return points;
+    }
+
+    public int getLineWidth() {
+        return lineWidth;
+    }
+
+    public String getLineColor() {
+        return lineColor;
+    }
+
+    public String getFillColor() {
+        return fillColor;
+    }
+
+    public boolean isFirstAppearance() {
+        return isFirstAppearance;
+    }
+
+    @Override
+    public String toString() {
+        return "SetShapeMarkerAction{" +
+                "markerIdentifier=" + getMarkerIdentifier() +
+                ", label='" + label + '\'' +
+                ", detail='" + detail + '\'' +
+                ", points=" + points +
+                ", lineWidth=" + lineWidth +
+                ", lineColor='" + lineColor + '\'' +
+                ", fillColor='" + fillColor + '\'' +
+                ", isFirstAppearance=" + isFirstAppearance +
+                '}';
+    }
+}

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/markers/MarkerGroup.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/markers/MarkerGroup.java
@@ -12,7 +12,8 @@ public record MarkerGroup(
         double minDistance,
         double maxDistance,
         int lineWidth,
-        String lineColor) {
+        String lineColor,
+        String fillColor) {
     public static final MarkerGroup DEFAULT_POI_GROUP = new MarkerGroup(
             "[poi]",
             MarkerGroupMatchType.STARTS_WITH,
@@ -25,9 +26,10 @@ public record MarkerGroup(
             0.0,
             10000000.0,
             2,
-            "#FF0000FF");
+            "#FF0000FF",
+            "#FF000033");
 
     public MarkerGroup withType(MarkerGroupType type) {
-        return new MarkerGroup(prefix, matchType, type, name, icon, offsetX, offsetY, defaultHidden, minDistance, maxDistance, lineWidth, lineColor);
+        return new MarkerGroup(prefix, matchType, type, name, icon, offsetX, offsetY, defaultHidden, minDistance, maxDistance, lineWidth, lineColor, fillColor);
     }
 }

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/markers/MarkerGroupType.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/markers/MarkerGroupType.java
@@ -2,5 +2,6 @@ package com.tpwalke2.bluemapsignmarkers.core.markers;
 
 public enum MarkerGroupType {
     POI,
-    LINE
+    LINE,
+    SHAPE
 }

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/markers/ShapeMarkerIdentifier.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/markers/ShapeMarkerIdentifier.java
@@ -1,0 +1,7 @@
+package com.tpwalke2.bluemapsignmarkers.core.markers;
+
+public record ShapeMarkerIdentifier(String label, MarkerSetIdentifier parentSet) implements DispatchedMarkerIdentifier {
+    public String getId() {
+        return "shape:" + label;
+    }
+}

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/ShapeGroupResolver.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/ShapeGroupResolver.java
@@ -1,0 +1,16 @@
+package com.tpwalke2.bluemapsignmarkers.core.signs;
+
+import java.util.Collection;
+import java.util.List;
+
+// Mirrors LineGroupResolver (see docs/adr/0002-shape-duplicates-line-pattern.md) - a SHAPE's members are
+// resolved identically to a LINE's (same parent map/prefix/label filter, same createdAtMillis-then-position
+// ordering), so this delegates to the shared implementation rather than duplicating the stream pipeline.
+public class ShapeGroupResolver {
+    private ShapeGroupResolver() {
+    }
+
+    public static List<SignEntry> members(Collection<SignEntry> allSigns, String parentMap, String prefix, String label) {
+        return LineGroupResolver.members(allSigns, parentMap, prefix, label);
+    }
+}

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignManager.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignManager.java
@@ -147,7 +147,7 @@ public class SignManager implements IResetHandler {
             }
         }
 
-        dispatchTransition(this::getAllSigns, key, oldRep, newRep, actionFactory, false);
+        dispatchTransition(this::getAllSigns, key, oldRep, newRep, actionFactory, false, prefixGroupMap);
     }
 
     private synchronized void removeByKey(SignEntryKey key) {
@@ -162,7 +162,7 @@ public class SignManager implements IResetHandler {
 
         var config = runtimeConfig;
         var oldRep = SignTransitionResolver.computeRepresentation(removed, config.prefixGroupMap());
-        dispatchTransition(this::getAllSigns, key, oldRep, null, config.actionFactory(), false);
+        dispatchTransition(this::getAllSigns, key, oldRep, null, config.actionFactory(), false, config.prefixGroupMap());
     }
 
     // Both call sites (live sign edits/removals from the mixins, and the reload loop below) run on their
@@ -176,9 +176,10 @@ public class SignManager implements IResetHandler {
             SignTransitionResolver.Representation oldRep,
             SignTransitionResolver.Representation newRep,
             ActionFactory actionFactory,
-            boolean isReload) {
+            boolean isReload,
+            Map<String, MarkerGroup> currentPrefixGroupMap) {
         try {
-            var action = SignTransitionResolver.computeTransitionAction(allSignsSupplier, key, oldRep, newRep, actionFactory, isReload);
+            var action = SignTransitionResolver.computeTransitionAction(allSignsSupplier, key, oldRep, newRep, actionFactory, isReload, currentPrefixGroupMap);
             if (action != null) {
                 LOGGER.debug("Dispatching marker action for {}: {}", key, action);
                 blueMapAPIConnector.dispatch(action);
@@ -249,7 +250,7 @@ public class SignManager implements IResetHandler {
             var key = keyAndOldRep.getKey();
             var current = signCache.get(key);
             var newRep = current == null ? null : SignTransitionResolver.computeRepresentation(current, newConfig.prefixGroupMap());
-            dispatchTransition(this::getAllSigns, key, keyAndOldRep.getValue(), newRep, newConfig.actionFactory(), true);
+            dispatchTransition(this::getAllSigns, key, keyAndOldRep.getValue(), newRep, newConfig.actionFactory(), true, newConfig.prefixGroupMap());
         }
     }
 

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolver.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolver.java
@@ -69,7 +69,8 @@ public class SignTransitionResolver {
             Representation oldRep,
             Representation newRep,
             ActionFactory actionFactory,
-            boolean isReload) {
+            boolean isReload,
+            Map<String, MarkerGroup> currentPrefixGroupMap) {
         if (oldRep == null && newRep == null) return null;
 
         if (oldRep == null) {
@@ -77,7 +78,7 @@ public class SignTransitionResolver {
         }
 
         if (newRep == null) {
-            return leaveEffect(allSignsSupplier, key, oldRep, actionFactory);
+            return leaveEffect(allSignsSupplier, key, oldRep, actionFactory, currentPrefixGroupMap);
         }
 
         var oldType = oldRep.group().type();
@@ -106,7 +107,7 @@ public class SignTransitionResolver {
 
         var effects = new ArrayList<MarkerAction>(2);
 
-        var leave = leaveEffect(allSignsSupplier, key, oldRep, actionFactory);
+        var leave = leaveEffect(allSignsSupplier, key, oldRep, actionFactory, currentPrefixGroupMap);
         if (leave != null) effects.add(leave);
 
         var join = joinEffect(allSignsSupplier, key, newRep, actionFactory, false);
@@ -119,12 +120,24 @@ public class SignTransitionResolver {
 
     // Dispatches the "this sign no longer holds this representation" effect for whichever type the
     // representation belongs to - a plain POI remove, or a LINE/SHAPE recompute-or-remove.
-    private static MarkerAction leaveEffect(Supplier<List<SignEntry>> allSignsSupplier, SignEntryKey key, Representation rep, ActionFactory actionFactory) {
+    private static MarkerAction leaveEffect(Supplier<List<SignEntry>> allSignsSupplier, SignEntryKey key, Representation rep, ActionFactory actionFactory, Map<String, MarkerGroup> currentPrefixGroupMap) {
         return switch (rep.group().type()) {
             case POI -> actionFactory.createRemovePOIAction(key.x(), key.y(), key.z(), key.parentMap(), rep.group());
-            case LINE -> lineLeaveAction(allSignsSupplier, key.parentMap(), rep, actionFactory);
-            case SHAPE -> shapeLeaveAction(allSignsSupplier, key.parentMap(), rep, actionFactory);
+            case LINE -> lineLeaveAction(allSignsSupplier, key.parentMap(), rep, actionFactory, currentPrefixGroupMap);
+            case SHAPE -> shapeLeaveAction(allSignsSupplier, key.parentMap(), rep, actionFactory, currentPrefixGroupMap);
         };
+    }
+
+    // True once rep's prefix no longer resolves to a same-typed group under the current config - i.e. the
+    // group was deleted, reassigned to a different prefix, or had its type flipped (e.g. SHAPE -> POI).
+    // When true, every sign still sharing rep's old prefix/label is undergoing this same transition
+    // simultaneously, so LineGroupResolver/ShapeGroupResolver's raw prefix/label membership count (which
+    // knows nothing about group type) can't be trusted to decide recompute-vs-remove: it would see the
+    // other members still "present" and recompute the old multi-point marker instead of retiring it. See
+    // agent-context/reviews/review-2026-08-20.md.
+    private static boolean groupIdentityObsolete(Representation rep, Map<String, MarkerGroup> currentPrefixGroupMap) {
+        var currentGroup = currentPrefixGroupMap.get(rep.group().prefix());
+        return currentGroup == null || currentGroup.type() != rep.group().type();
     }
 
     // Dispatches the "this sign now holds this representation" effect for whichever type the
@@ -156,7 +169,11 @@ public class SignTransitionResolver {
     // present in signCache under this group/label by the time this is called). Dispatches Set if ≥2
     // members remain, Remove if it drops below 2 and a marker existed before (i.e. exactly 1 remains -
     // meaning there were 2 before), or nothing if there was never a marker to begin with (0 remain).
-    private static MarkerAction lineLeaveAction(Supplier<List<SignEntry>> allSignsSupplier, String parentMap, Representation rep, ActionFactory actionFactory) {
+    private static MarkerAction lineLeaveAction(Supplier<List<SignEntry>> allSignsSupplier, String parentMap, Representation rep, ActionFactory actionFactory, Map<String, MarkerGroup> currentPrefixGroupMap) {
+        if (groupIdentityObsolete(rep, currentPrefixGroupMap)) {
+            return actionFactory.createRemoveLineAction(parentMap, rep.group(), rep.label());
+        }
+
         var members = LineGroupResolver.members(allSignsSupplier.get(), parentMap, rep.group().prefix(), rep.label());
 
         if (members.size() >= 2) {
@@ -188,7 +205,11 @@ public class SignTransitionResolver {
         return actionFactory.createSetShapeAction(parentMap, rep.group(), rep.label(), rep.label(), toPoints(members), isFirstAppearance);
     }
 
-    private static MarkerAction shapeLeaveAction(Supplier<List<SignEntry>> allSignsSupplier, String parentMap, Representation rep, ActionFactory actionFactory) {
+    private static MarkerAction shapeLeaveAction(Supplier<List<SignEntry>> allSignsSupplier, String parentMap, Representation rep, ActionFactory actionFactory, Map<String, MarkerGroup> currentPrefixGroupMap) {
+        if (groupIdentityObsolete(rep, currentPrefixGroupMap)) {
+            return actionFactory.createRemoveShapeAction(parentMap, rep.group(), rep.label());
+        }
+
         var members = ShapeGroupResolver.members(allSignsSupplier.get(), parentMap, rep.group().prefix(), rep.label());
 
         if (members.size() >= SHAPE_MIN_MEMBERS) {

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolver.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolver.java
@@ -176,8 +176,8 @@ public class SignTransitionResolver {
 
     // SHAPE mirrors LINE's join/leave/recompute shape (see lineJoinAction/lineLeaveAction above), but at a
     // 3-member render threshold instead of 2 - see docs/adr/0002-shape-duplicates-line-pattern.md. Points
-    // stay ordered by createdAtMillis (toPoints/ShapeGroupResolver.members), so the oldest member - the
-    // shape's Y anchor - is always points.get(0).
+    // stay ordered by createdAtMillis (toPoints/ShapeGroupResolver.members) purely for polygon vertex order;
+    // the shape's Y anchor (BlueMapAPIConnector.setShapeMarker) is the tallest member, not the oldest.
     private static final int SHAPE_MIN_MEMBERS = 3;
 
     private static MarkerAction shapeJoinAction(Supplier<List<SignEntry>> allSignsSupplier, String parentMap, Representation rep, ActionFactory actionFactory, boolean sameGroupRecompute) {

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolver.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolver.java
@@ -73,15 +73,11 @@ public class SignTransitionResolver {
         if (oldRep == null && newRep == null) return null;
 
         if (oldRep == null) {
-            return newRep.group().type() == MarkerGroupType.POI
-                    ? actionFactory.createAddPOIAction(key.x(), key.y(), key.z(), key.parentMap(), newRep.label(), newRep.detail(), newRep.group())
-                    : lineJoinAction(allSignsSupplier, key.parentMap(), newRep, actionFactory, false);
+            return joinEffect(allSignsSupplier, key, newRep, actionFactory, false);
         }
 
         if (newRep == null) {
-            return oldRep.group().type() == MarkerGroupType.POI
-                    ? actionFactory.createRemovePOIAction(key.x(), key.y(), key.z(), key.parentMap(), oldRep.group())
-                    : lineLeaveAction(allSignsSupplier, key.parentMap(), oldRep, actionFactory);
+            return leaveEffect(allSignsSupplier, key, oldRep, actionFactory);
         }
 
         var oldType = oldRep.group().type();
@@ -100,26 +96,46 @@ public class SignTransitionResolver {
             return actionFactory.createChangeGroupPOIAction(key.x(), key.y(), key.z(), key.parentMap(), newRep.label(), newRep.detail(), oldRep.group(), newRep.group());
         }
 
-        if (oldType == MarkerGroupType.LINE && newType == MarkerGroupType.LINE && sameGroupAndLabel(oldRep, newRep)) {
+        // Same-group-and-label recompute for either multi-point type (LINE↔LINE or SHAPE↔SHAPE); a
+        // type-pair mismatch (or same type but a different group/label) falls through to the general
+        // leave+join bundling below.
+        if (oldType == newType && oldType != MarkerGroupType.POI && sameGroupAndLabel(oldRep, newRep)) {
             if (oldRep.detail().equals(newRep.detail()) && !isReload) return null;
-            return lineJoinAction(allSignsSupplier, key.parentMap(), newRep, actionFactory, true);
+            return joinEffect(allSignsSupplier, key, newRep, actionFactory, true);
         }
 
         var effects = new ArrayList<MarkerAction>(2);
 
-        var leave = oldType == MarkerGroupType.POI
-                ? actionFactory.createRemovePOIAction(key.x(), key.y(), key.z(), key.parentMap(), oldRep.group())
-                : lineLeaveAction(allSignsSupplier, key.parentMap(), oldRep, actionFactory);
+        var leave = leaveEffect(allSignsSupplier, key, oldRep, actionFactory);
         if (leave != null) effects.add(leave);
 
-        var join = newType == MarkerGroupType.POI
-                ? actionFactory.createAddPOIAction(key.x(), key.y(), key.z(), key.parentMap(), newRep.label(), newRep.detail(), newRep.group())
-                : lineJoinAction(allSignsSupplier, key.parentMap(), newRep, actionFactory, false);
+        var join = joinEffect(allSignsSupplier, key, newRep, actionFactory, false);
         if (join != null) effects.add(join);
 
         if (effects.isEmpty()) return null;
         if (effects.size() == 1) return effects.get(0);
         return new GroupTransitionMarkerAction(effects);
+    }
+
+    // Dispatches the "this sign no longer holds this representation" effect for whichever type the
+    // representation belongs to - a plain POI remove, or a LINE/SHAPE recompute-or-remove.
+    private static MarkerAction leaveEffect(Supplier<List<SignEntry>> allSignsSupplier, SignEntryKey key, Representation rep, ActionFactory actionFactory) {
+        return switch (rep.group().type()) {
+            case POI -> actionFactory.createRemovePOIAction(key.x(), key.y(), key.z(), key.parentMap(), rep.group());
+            case LINE -> lineLeaveAction(allSignsSupplier, key.parentMap(), rep, actionFactory);
+            case SHAPE -> shapeLeaveAction(allSignsSupplier, key.parentMap(), rep, actionFactory);
+        };
+    }
+
+    // Dispatches the "this sign now holds this representation" effect for whichever type the
+    // representation belongs to - a plain POI add, or a LINE/SHAPE recompute-or-first-appearance.
+    // sameGroupRecompute is only meaningful for LINE/SHAPE (see lineJoinAction/shapeJoinAction).
+    private static MarkerAction joinEffect(Supplier<List<SignEntry>> allSignsSupplier, SignEntryKey key, Representation rep, ActionFactory actionFactory, boolean sameGroupRecompute) {
+        return switch (rep.group().type()) {
+            case POI -> actionFactory.createAddPOIAction(key.x(), key.y(), key.z(), key.parentMap(), rep.label(), rep.detail(), rep.group());
+            case LINE -> lineJoinAction(allSignsSupplier, key.parentMap(), rep, actionFactory, sameGroupRecompute);
+            case SHAPE -> shapeJoinAction(allSignsSupplier, key.parentMap(), rep, actionFactory, sameGroupRecompute);
+        };
     }
 
     // Recomputes a line group including the current sign (it must already be in signCache under this
@@ -156,5 +172,33 @@ public class SignTransitionResolver {
 
     private static List<LinePoint> toPoints(List<SignEntry> members) {
         return members.stream().map(e -> new LinePoint(e.key().x(), e.key().y(), e.key().z())).toList();
+    }
+
+    // SHAPE mirrors LINE's join/leave/recompute shape (see lineJoinAction/lineLeaveAction above), but at a
+    // 3-member render threshold instead of 2 - see docs/adr/0002-shape-duplicates-line-pattern.md. Points
+    // stay ordered by createdAtMillis (toPoints/ShapeGroupResolver.members), so the oldest member - the
+    // shape's Y anchor - is always points.get(0).
+    private static final int SHAPE_MIN_MEMBERS = 3;
+
+    private static MarkerAction shapeJoinAction(Supplier<List<SignEntry>> allSignsSupplier, String parentMap, Representation rep, ActionFactory actionFactory, boolean sameGroupRecompute) {
+        var members = ShapeGroupResolver.members(allSignsSupplier.get(), parentMap, rep.group().prefix(), rep.label());
+        if (members.size() < SHAPE_MIN_MEMBERS) return null;
+
+        var isFirstAppearance = !sameGroupRecompute && members.size() == SHAPE_MIN_MEMBERS;
+        return actionFactory.createSetShapeAction(parentMap, rep.group(), rep.label(), rep.label(), toPoints(members), isFirstAppearance);
+    }
+
+    private static MarkerAction shapeLeaveAction(Supplier<List<SignEntry>> allSignsSupplier, String parentMap, Representation rep, ActionFactory actionFactory) {
+        var members = ShapeGroupResolver.members(allSignsSupplier.get(), parentMap, rep.group().prefix(), rep.label());
+
+        if (members.size() >= SHAPE_MIN_MEMBERS) {
+            return actionFactory.createSetShapeAction(parentMap, rep.group(), rep.label(), rep.label(), toPoints(members), false);
+        }
+
+        if (members.size() == SHAPE_MIN_MEMBERS - 1) {
+            return actionFactory.createRemoveShapeAction(parentMap, rep.group(), rep.label());
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolver.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolver.java
@@ -52,7 +52,7 @@ public class SignTransitionResolver {
     }
 
     static boolean sameGroupAndLabel(Representation a, Representation b) {
-        return a.group().prefix().equals(b.group().prefix()) && a.label().equals(b.label());
+        return a.group().equals(b.group()) && a.label().equals(b.label());
     }
 
     // The (oldRepresentation, newRepresentation) transition table from
@@ -97,9 +97,10 @@ public class SignTransitionResolver {
             return actionFactory.createChangeGroupPOIAction(key.x(), key.y(), key.z(), key.parentMap(), newRep.label(), newRep.detail(), oldRep.group(), newRep.group());
         }
 
-        // Same-group-and-label recompute for either multi-point type (LINE↔LINE or SHAPE↔SHAPE); a
-        // type-pair mismatch (or same type but a different group/label) falls through to the general
-        // leave+join bundling below.
+        // Same-group-and-label recompute for either multi-point type (LINE↔LINE or SHAPE↔SHAPE); sameGroupAndLabel
+        // requires the whole MarkerGroup to be unchanged (not just its type/prefix), since any other edit - e.g. a
+        // rename - moves the marker to a different BlueMap marker set (see groupIdentityObsolete) and must go
+        // through the general leave+join bundling below instead, or the old marker set would never get cleared.
         if (oldType == newType && oldType != MarkerGroupType.POI && sameGroupAndLabel(oldRep, newRep)) {
             if (oldRep.detail().equals(newRep.detail()) && !isReload) return null;
             return joinEffect(allSignsSupplier, key, newRep, actionFactory, true);
@@ -128,16 +129,18 @@ public class SignTransitionResolver {
         };
     }
 
-    // True once rep's prefix no longer resolves to a same-typed group under the current config - i.e. the
-    // group was deleted, reassigned to a different prefix, or had its type flipped (e.g. SHAPE -> POI).
-    // When true, every sign still sharing rep's old prefix/label is undergoing this same transition
-    // simultaneously, so LineGroupResolver/ShapeGroupResolver's raw prefix/label membership count (which
-    // knows nothing about group type) can't be trusted to decide recompute-vs-remove: it would see the
-    // other members still "present" and recompute the old multi-point marker instead of retiring it. See
+    // True once rep's prefix no longer resolves to the exact same group under the current config - i.e. the
+    // group was deleted, reassigned to a different prefix, had its type flipped (e.g. SHAPE -> POI), or was
+    // otherwise edited (e.g. renamed, which moves its markers to a different BlueMap marker set - see
+    // BlueMapAPIConnector.getMarkerSets keying MarkerSet lookup by MarkerGroup.name()). When true, every
+    // sign still sharing rep's old prefix/label is undergoing this same transition simultaneously, so
+    // LineGroupResolver/ShapeGroupResolver's raw prefix/label membership count (which knows nothing about
+    // group identity) can't be trusted to decide recompute-vs-remove: it would see the other members still
+    // "present" and recompute the old multi-point marker instead of retiring it. See
     // agent-context/reviews/review-2026-08-20.md.
     private static boolean groupIdentityObsolete(Representation rep, Map<String, MarkerGroup> currentPrefixGroupMap) {
         var currentGroup = currentPrefixGroupMap.get(rep.group().prefix());
-        return currentGroup == null || currentGroup.type() != rep.group().type();
+        return currentGroup == null || !currentGroup.equals(rep.group());
     }
 
     // Dispatches the "this sign now holds this representation" effect for whichever type the

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProviderTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProviderTest.java
@@ -1,13 +1,23 @@
 package com.tpwalke2.bluemapsignmarkers.config;
 
+import com.tpwalke2.bluemapsignmarkers.Constants;
+import com.tpwalke2.bluemapsignmarkers.config.models.BMSMConfigV2;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupMatchType;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -15,6 +25,29 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ConfigProviderTest {
+
+    // Captures the log messages the mod's logger emits while running action (and stashes action's result
+    // into result[0]), so tests can assert that warnOnTypeFieldMismatches actually logs a warning rather
+    // than only checking the config still loads.
+    private static List<String> captureWarnMessages(Supplier<BMSMConfigV2> action, BMSMConfigV2[] result) {
+        var logger = (Logger) LogManager.getLogger(Constants.MOD_ID);
+        var messages = new ArrayList<String>();
+        var appender = new AbstractAppender("test-capture", null, null, false, Property.EMPTY_ARRAY) {
+            @Override
+            public void append(LogEvent event) {
+                messages.add(event.getMessage().getFormattedMessage());
+            }
+        };
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            result[0] = action.get();
+        } finally {
+            logger.removeAppender(appender);
+            appender.stop();
+        }
+        return messages;
+    }
 
     @Test
     void loadConfigCreatesAndPersistsDefaultsWhenFileIsAbsent(@TempDir Path tempDir) {
@@ -264,12 +297,16 @@ class ConfigProviderTest {
                 }
                 """);
 
-        var config = ConfigProvider.loadConfig(path);
+        var result = new BMSMConfigV2[1];
+        var warnings = captureWarnMessages(() -> ConfigProvider.loadConfig(path), result);
+        var config = result[0];
 
         assertEquals(1, config.getMarkerGroups().length);
         var group = config.getMarkerGroups()[0];
         assertEquals(MarkerGroupType.POI, group.type());
         assertEquals("[poi]", group.prefix());
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("lineWidth")));
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("lineColor")));
     }
 
     @Test
@@ -396,12 +433,15 @@ class ConfigProviderTest {
                 }
                 """);
 
-        var config = ConfigProvider.loadConfig(path);
+        var result = new BMSMConfigV2[1];
+        var warnings = captureWarnMessages(() -> ConfigProvider.loadConfig(path), result);
+        var config = result[0];
 
         assertEquals(1, config.getMarkerGroups().length);
         var group = config.getMarkerGroups()[0];
         assertEquals(MarkerGroupType.POI, group.type());
         assertEquals("#00FF00FF", group.fillColor());
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("fillColor")));
     }
 
     @Test
@@ -415,12 +455,15 @@ class ConfigProviderTest {
                 }
                 """);
 
-        var config = ConfigProvider.loadConfig(path);
+        var result = new BMSMConfigV2[1];
+        var warnings = captureWarnMessages(() -> ConfigProvider.loadConfig(path), result);
+        var config = result[0];
 
         assertEquals(1, config.getMarkerGroups().length);
         var group = config.getMarkerGroups()[0];
         assertEquals(MarkerGroupType.LINE, group.type());
         assertEquals("#00FF00FF", group.fillColor());
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("fillColor")));
     }
 
     @Test
@@ -434,7 +477,9 @@ class ConfigProviderTest {
                 }
                 """);
 
-        var config = ConfigProvider.loadConfig(path);
+        var result = new BMSMConfigV2[1];
+        var warnings = captureWarnMessages(() -> ConfigProvider.loadConfig(path), result);
+        var config = result[0];
 
         assertEquals(1, config.getMarkerGroups().length);
         var group = config.getMarkerGroups()[0];
@@ -442,6 +487,9 @@ class ConfigProviderTest {
         assertEquals("icon.png", group.icon());
         assertEquals(1, group.offsetX());
         assertEquals(2, group.offsetY());
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("icon")));
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("offsetX")));
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("offsetY")));
     }
 
     @Test

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProviderTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProviderTest.java
@@ -293,6 +293,158 @@ class ConfigProviderTest {
     }
 
     @Test
+    void loadConfigDefaultsFillColorForAShapeGroupWhenOmitted(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[shape]", "name": "Shape Group", "type": "SHAPE" }
+                  ]
+                }
+                """);
+
+        var config = ConfigProvider.loadConfig(path);
+
+        assertEquals(1, config.getMarkerGroups().length);
+        var group = config.getMarkerGroups()[0];
+        assertEquals(MarkerGroupType.SHAPE, group.type());
+        assertEquals("#FF000033", group.fillColor());
+    }
+
+    @Test
+    void loadConfigPreservesExplicitFillColorForAShapeGroup(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[shape]", "name": "Shape Group", "type": "SHAPE", "fillColor": "#00FF0080" }
+                  ]
+                }
+                """);
+
+        var config = ConfigProvider.loadConfig(path);
+
+        assertEquals(1, config.getMarkerGroups().length);
+        var group = config.getMarkerGroups()[0];
+        assertEquals("#00FF0080", group.fillColor());
+    }
+
+    @Test
+    void loadConfigFallsBackToDefaultFillColorWhenMalformed(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[shape]", "name": "Shape Group", "type": "SHAPE", "fillColor": "notacolor" }
+                  ]
+                }
+                """);
+
+        var config = ConfigProvider.loadConfig(path);
+
+        assertEquals(1, config.getMarkerGroups().length);
+        var group = config.getMarkerGroups()[0];
+        assertEquals("#FF000033", group.fillColor());
+    }
+
+    @Test
+    void loadConfigAllowsExplicitLineWidthAndLineColorOnAShapeGroup(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[shape]", "name": "Shape Group", "type": "SHAPE", "lineWidth": 5, "lineColor": "#00FF00FF" }
+                  ]
+                }
+                """);
+
+        var config = ConfigProvider.loadConfig(path);
+
+        assertEquals(1, config.getMarkerGroups().length);
+        var group = config.getMarkerGroups()[0];
+        assertEquals(5, group.lineWidth());
+        assertEquals("#00FF00FF", group.lineColor());
+    }
+
+    @Test
+    void loadConfigFallsBackToDefaultLineWidthAndLineColorForAShapeGroupWhenMalformed(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[shape]", "name": "Shape Group", "type": "SHAPE", "lineWidth": -5, "lineColor": "notacolor" }
+                  ]
+                }
+                """);
+
+        var config = ConfigProvider.loadConfig(path);
+
+        assertEquals(1, config.getMarkerGroups().length);
+        var group = config.getMarkerGroups()[0];
+        assertEquals(2, group.lineWidth());
+        assertEquals("#FF0000FF", group.lineColor());
+    }
+
+    @Test
+    void loadConfigStillLoadsAPOIGroupWithFillColorSet(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[poi]", "name": "POI Group", "type": "POI", "fillColor": "#00FF00FF" }
+                  ]
+                }
+                """);
+
+        var config = ConfigProvider.loadConfig(path);
+
+        assertEquals(1, config.getMarkerGroups().length);
+        var group = config.getMarkerGroups()[0];
+        assertEquals(MarkerGroupType.POI, group.type());
+        assertEquals("#00FF00FF", group.fillColor());
+    }
+
+    @Test
+    void loadConfigStillLoadsALineGroupWithFillColorSet(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[line]", "name": "Line Group", "type": "LINE", "fillColor": "#00FF00FF" }
+                  ]
+                }
+                """);
+
+        var config = ConfigProvider.loadConfig(path);
+
+        assertEquals(1, config.getMarkerGroups().length);
+        var group = config.getMarkerGroups()[0];
+        assertEquals(MarkerGroupType.LINE, group.type());
+        assertEquals("#00FF00FF", group.fillColor());
+    }
+
+    @Test
+    void loadConfigStillLoadsAShapeGroupWithIconAndOffsetsSet(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[shape]", "name": "Shape Group", "type": "SHAPE", "icon": "icon.png", "offsetX": 1, "offsetY": 2 }
+                  ]
+                }
+                """);
+
+        var config = ConfigProvider.loadConfig(path);
+
+        assertEquals(1, config.getMarkerGroups().length);
+        var group = config.getMarkerGroups()[0];
+        assertEquals(MarkerGroupType.SHAPE, group.type());
+        assertEquals("icon.png", group.icon());
+        assertEquals(1, group.offsetX());
+        assertEquals(2, group.offsetY());
+    }
+
+    @Test
     void saveAndLoadConfigRoundTripNonAsciiMarkerGroupNamesThroughUtf8(@TempDir Path tempDir) throws IOException {
         var path = tempDir.resolve("BMSM-Core.json");
         var original = new com.tpwalke2.bluemapsignmarkers.config.models.BMSMConfigV2(
@@ -308,7 +460,8 @@ class ConfigProviderTest {
                         0.0,
                         10000000.0,
                         2,
-                        "#FF0000FF"));
+                        "#FF0000FF",
+                        "#FF000033"));
 
         ConfigProvider.saveConfig(original, path);
         var reloaded = ConfigProvider.loadConfig(path);

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/actions/ActionFactoryTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/actions/ActionFactoryTest.java
@@ -150,6 +150,51 @@ class ActionFactoryTest {
     }
 
     @Test
+    void createSetShapeActionBuildsTheShapeMarkerIdentifierAndActionFields() {
+        var factory = new ActionFactory(new MarkerSetIdentifierCollection());
+        var group = shapeMarkerGroup("[shape]");
+        var points = List.of(new LinePoint(1, 2, 3), new LinePoint(4, 5, 6), new LinePoint(7, 8, 9));
+
+        var action = factory.createSetShapeAction("world", group, "label", "detail", points, true);
+        var identifier = (com.tpwalke2.bluemapsignmarkers.core.markers.ShapeMarkerIdentifier) action.getMarkerIdentifier();
+
+        assertEquals("label", identifier.label());
+        assertEquals("world", identifier.parentSet().mapId());
+        assertEquals(group, identifier.parentSet().markerGroup());
+        assertEquals("label", action.getLabel());
+        assertEquals("detail", action.getDetail());
+        assertEquals(points, action.getPoints());
+        assertEquals(group.lineWidth(), action.getLineWidth());
+        assertEquals(group.lineColor(), action.getLineColor());
+        assertEquals(group.fillColor(), action.getFillColor());
+        assertTrue(action.isFirstAppearance());
+    }
+
+    @Test
+    void createRemoveShapeActionBuildsTheShapeMarkerIdentifier() {
+        var factory = new ActionFactory(new MarkerSetIdentifierCollection());
+        var group = shapeMarkerGroup("[shape]");
+
+        var action = factory.createRemoveShapeAction("world", group, "label");
+        var identifier = (com.tpwalke2.bluemapsignmarkers.core.markers.ShapeMarkerIdentifier) action.getMarkerIdentifier();
+
+        assertEquals("label", identifier.label());
+        assertEquals("world", identifier.parentSet().mapId());
+        assertEquals(group, identifier.parentSet().markerGroup());
+    }
+
+    @Test
+    void shapeActionsForTheSameMapAndGroupReuseTheSameMarkerSetIdentifierAsPOIActions() {
+        var factory = new ActionFactory(new MarkerSetIdentifierCollection());
+        var group = shapeMarkerGroup("[shape]");
+
+        var set = factory.createSetShapeAction("world", group, "label", "detail", List.of(), true);
+        var removed = factory.createRemoveShapeAction("world", group, "other label");
+
+        assertSame(set.getMarkerIdentifier().parentSet(), removed.getMarkerIdentifier().parentSet());
+    }
+
+    @Test
     void lineActionsForTheSameMapAndGroupReuseTheSameMarkerSetIdentifierAsPOIActions() {
         var factory = new ActionFactory(new MarkerSetIdentifierCollection());
         var group = lineMarkerGroup("[line]");
@@ -163,12 +208,18 @@ class ActionFactoryTest {
     private static MarkerGroup markerGroup(String prefix) {
         return new MarkerGroup(
                 prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, prefix, "icon.png", 0, 0, false, 0, 0,
-                2, "#FF0000FF");
+                2, "#FF0000FF", "#FF000033");
     }
 
     private static MarkerGroup lineMarkerGroup(String prefix) {
         return new MarkerGroup(
                 prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.LINE, prefix, "icon.png", 0, 0, false, 0, 0,
-                2, "#FF0000FF");
+                2, "#FF0000FF", "#FF000033");
+    }
+
+    private static MarkerGroup shapeMarkerGroup(String prefix) {
+        return new MarkerGroup(
+                prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.SHAPE, prefix, null, 0, 0, false, 0, 0,
+                2, "#FF0000FF", "#FF000033");
     }
 }

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/markers/MarkerSetIdentifierCollectionTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/markers/MarkerSetIdentifierCollectionTest.java
@@ -115,6 +115,6 @@ class MarkerSetIdentifierCollectionTest {
     private static MarkerGroup markerGroup(String prefix) {
         return new MarkerGroup(
                 prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, prefix, "icon.png", 0, 0, false, 0, 0,
-                2, "#FF0000FF");
+                2, "#FF0000FF", "#FF000033");
     }
 }

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/ParsingContextTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/ParsingContextTest.java
@@ -64,6 +64,6 @@ class ParsingContextTest {
     private static MarkerGroup markerGroup(String prefix) {
         return new MarkerGroup(
                 prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, prefix, "icon.png", 0, 0, false, 0, 0,
-                2, "#FF0000FF");
+                2, "#FF0000FF", "#FF000033");
     }
 }

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/ShapeGroupResolverTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/ShapeGroupResolverTest.java
@@ -1,0 +1,68 @@
+package com.tpwalke2.bluemapsignmarkers.core.signs;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// Mirrors LineGroupResolverTest - ShapeGroupResolver.members resolves identically to LineGroupResolver.members
+// (see docs/adr/0002-shape-duplicates-line-pattern.md).
+class ShapeGroupResolverTest {
+
+    private static SignEntry signEntry(int x, int y, int z, String parentMap, String prefix, String label, long createdAtMillis) {
+        return new SignEntry(
+                new SignEntryKey(x, y, z, parentMap),
+                "unknown",
+                new SignLinesParseResult(prefix, label, "detail"),
+                new SignLinesParseResult(null, "", ""),
+                createdAtMillis,
+                null,
+                null);
+    }
+
+    @Test
+    void returnsOnlyEntriesMatchingParentMapPrefixAndLabel() {
+        var member = signEntry(0, 64, 0, "minecraft:overworld", "[region]", "North Farm", 1000L);
+        var otherMap = signEntry(1, 64, 1, "minecraft:the_nether", "[region]", "North Farm", 1001L);
+        var otherPrefix = signEntry(2, 64, 2, "minecraft:overworld", "[poi]", "North Farm", 1002L);
+        var otherLabel = signEntry(3, 64, 3, "minecraft:overworld", "[region]", "South Farm", 1003L);
+
+        var result = ShapeGroupResolver.members(
+                List.of(member, otherMap, otherPrefix, otherLabel), "minecraft:overworld", "[region]", "North Farm");
+
+        assertEquals(List.of(member), result);
+    }
+
+    @Test
+    void ordersMembersByCreatedAtMillisAscending() {
+        var third = signEntry(0, 64, 0, "minecraft:overworld", "[region]", "North Farm", 3000L);
+        var first = signEntry(1, 64, 1, "minecraft:overworld", "[region]", "North Farm", 1000L);
+        var second = signEntry(2, 64, 2, "minecraft:overworld", "[region]", "North Farm", 2000L);
+
+        var result = ShapeGroupResolver.members(
+                List.of(third, first, second), "minecraft:overworld", "[region]", "North Farm");
+
+        assertEquals(List.of(first, second, third), result);
+    }
+
+    @Test
+    void breaksTiesOnDuplicateCreatedAtMillisByPositionXThenYThenZ() {
+        var higherZ = signEntry(0, 64, 2, "minecraft:overworld", "[region]", "North Farm", 1000L);
+        var higherY = signEntry(0, 65, 0, "minecraft:overworld", "[region]", "North Farm", 1000L);
+        var higherX = signEntry(1, 64, 0, "minecraft:overworld", "[region]", "North Farm", 1000L);
+        var lowest = signEntry(0, 64, 0, "minecraft:overworld", "[region]", "North Farm", 1000L);
+
+        var result = ShapeGroupResolver.members(
+                List.of(higherZ, higherY, higherX, lowest), "minecraft:overworld", "[region]", "North Farm");
+
+        assertEquals(List.of(lowest, higherZ, higherY, higherX), result);
+    }
+
+    @Test
+    void emptyInputProducesNoMembers() {
+        var result = ShapeGroupResolver.members(List.of(), "minecraft:overworld", "[region]", "North Farm");
+
+        assertEquals(List.of(), result);
+    }
+}

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignEntryHelperTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignEntryHelperTest.java
@@ -17,7 +17,7 @@ class SignEntryHelperTest {
     private static final SignEntryKey KEY = new SignEntryKey(1, 2, 3, "minecraft:overworld");
 
     private static MarkerGroup poiGroup(String prefix) {
-        return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, "Points of Interest", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF");
+        return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, "Points of Interest", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
     }
 
     private static SignEntry signEntry(SignLinesParseResult frontText, SignLinesParseResult backText) {

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignLinesParserTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignLinesParserTest.java
@@ -13,11 +13,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class SignLinesParserTest {
 
     private static MarkerGroup startsWithGroup(String prefix, String name) {
-        return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, name, null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF");
+        return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, name, null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
     }
 
     private static MarkerGroup regexGroup(String pattern, String name) {
-        return new MarkerGroup(pattern, MarkerGroupMatchType.REGEX, MarkerGroupType.POI, name, null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF");
+        return new MarkerGroup(pattern, MarkerGroupMatchType.REGEX, MarkerGroupType.POI, name, null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
     }
 
     @Test

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignManagerTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignManagerTest.java
@@ -22,7 +22,7 @@ class SignManagerTest {
 
     private static MarkerGroup regexGroup(String prefix) {
         return new MarkerGroup(prefix, MarkerGroupMatchType.REGEX, MarkerGroupType.POI,
-                "name", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF");
+                "name", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
     }
 
     @Test

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolverTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolverTest.java
@@ -518,7 +518,8 @@ class SignTransitionResolverTest {
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
         assertInstanceOf(RemoveMarkerAction.class, transition.effects().get(0));
-        assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(1));
+        var join = assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(1));
+        assertTrue(join.isFirstAppearance());
     }
 
     @Test
@@ -559,7 +560,8 @@ class SignTransitionResolverTest {
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
         assertInstanceOf(RemoveLineMarkerAction.class, transition.effects().get(0));
-        assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(1));
+        var join = assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(1));
+        assertTrue(join.isFirstAppearance());
     }
 
     @Test
@@ -599,7 +601,8 @@ class SignTransitionResolverTest {
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
         assertInstanceOf(RemoveMarkerAction.class, transition.effects().get(0));
-        assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(1));
+        var join = assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(1));
+        assertTrue(join.isFirstAppearance());
     }
 
     @Test
@@ -640,7 +643,8 @@ class SignTransitionResolverTest {
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
         assertInstanceOf(RemoveLineMarkerAction.class, transition.effects().get(0));
-        assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(1));
+        var join = assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(1));
+        assertTrue(join.isFirstAppearance());
     }
 
     @Test

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolverTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolverTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // Table-driven coverage of SignTransitionResolver.computeTransitionAction, one test per row/sub-branch
-// of the transition table in .scratch/line-markers/spec.md Â§6.
+// of the transition table in .scratch/line-markers/spec.md §6.
 class SignTransitionResolverTest {
 
     private static final String MAP = "minecraft:overworld";
@@ -41,8 +41,12 @@ class SignTransitionResolverTest {
     }
 
     private static MarkerGroup shapeGroup(String prefix) {
+        return shapeGroup(prefix, "name");
+    }
+
+    private static MarkerGroup shapeGroup(String prefix, String name) {
         return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.SHAPE,
-                "name", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
+                name, null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
     }
 
     private static SignEntry signEntry(int x, int y, int z, String prefix, String label, String detail, long createdAtMillis) {
@@ -689,5 +693,31 @@ class SignTransitionResolverTest {
         assertEquals(2, transition.effects().size());
         assertInstanceOf(RemoveShapeMarkerAction.class, transition.effects().get(0));
         assertInstanceOf(AddMarkerAction.class, transition.effects().get(1));
+    }
+
+    // Regression for a Copilot review finding on agent-context/reviews/copilot-review-2026-08-20.md: a reload
+    // where a SHAPE group is renamed (same prefix/type, different `name`, which is the BlueMap marker set key -
+    // see BlueMapAPIConnector.getMarkerSets) must not take the same-group-and-label recompute shortcut, or the
+    // old marker set is never cleared and the shape is duplicated instead of moved.
+    @Test
+    void shapeToShapeGroupRenameOnReloadBundlesRemoveOldSetAndAddNewSet() {
+        var oldGroup = shapeGroup("[region]", "Old Name");
+        var newGroup = shapeGroup("[region]", "New Name");
+        var first = signEntry(0, 64, 0, "[region]", "Plot", "d1", 1000L);
+        var second = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var third = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
+        var oldRep = rep(first, oldGroup);
+        var newRep = rep(first, newGroup);
+
+        var allSigns = List.of(first, second, third);
+        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, first.key(), oldRep, newRep, actionFactory(), true, Map.of(newGroup.prefix(), newGroup));
+
+        var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
+        assertEquals(2, transition.effects().size());
+        var leave = assertInstanceOf(RemoveShapeMarkerAction.class, transition.effects().get(0));
+        assertEquals(oldGroup, leave.getMarkerIdentifier().parentSet().markerGroup());
+        var join = assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(1));
+        assertEquals(newGroup, join.getMarkerIdentifier().parentSet().markerGroup());
+        assertEquals(3, join.getPoints().size());
     }
 }

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolverTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolverTest.java
@@ -6,7 +6,9 @@ import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.GroupTransitionMarke
 import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.MarkerAction;
 import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.RemoveLineMarkerAction;
 import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.RemoveMarkerAction;
+import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.RemoveShapeMarkerAction;
 import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.SetLineMarkerAction;
+import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.SetShapeMarkerAction;
 import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.UpdateMarkerAction;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroup;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupMatchType;
@@ -30,12 +32,17 @@ class SignTransitionResolverTest {
 
     private static MarkerGroup poiGroup(String prefix) {
         return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI,
-                "name", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF");
+                "name", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
     }
 
     private static MarkerGroup lineGroup(String prefix) {
         return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.LINE,
-                "name", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF");
+                "name", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
+    }
+
+    private static MarkerGroup shapeGroup(String prefix) {
+        return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.SHAPE,
+                "name", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
     }
 
     private static SignEntry signEntry(int x, int y, int z, String prefix, String label, String detail, long createdAtMillis) {
@@ -335,5 +342,324 @@ class SignTransitionResolverTest {
         var leave = assertInstanceOf(SetLineMarkerAction.class, transition.effects().get(0));
         assertEquals(2, leave.getPoints().size());
         assertInstanceOf(AddMarkerAction.class, transition.effects().get(1));
+    }
+
+    // --- SHAPE: join/leave/recompute at the 3-member threshold (mirrors the LINE table above, but at 3) ---
+
+    @Test
+    void noneToShapeWithFewerThanThreeMembersIsNoOp() {
+        var group = shapeGroup("[region]");
+        var first = signEntry(0, 64, 0, "[region]", "Plot", "d1", 1000L);
+        var second = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var newRep = rep(second, group);
+
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(first, second), second.key(), null, newRep, actionFactory(), false);
+
+        assertNull(action);
+    }
+
+    @Test
+    void noneToShapeAtExactlyThreeMembersDispatchesSetWithFirstAppearanceTrue() {
+        var group = shapeGroup("[region]");
+        var first = signEntry(0, 64, 0, "[region]", "Plot", "d1", 1000L);
+        var second = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var third = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
+        var newRep = rep(third, group);
+
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(first, second, third), third.key(), null, newRep, actionFactory(), false);
+
+        var set = assertInstanceOf(SetShapeMarkerAction.class, action);
+        assertTrue(set.isFirstAppearance());
+        assertEquals(3, set.getPoints().size());
+        assertEquals("Plot", set.getDetail());
+    }
+
+    @Test
+    void noneToShapeJoiningAFourthMemberDispatchesSetWithFirstAppearanceFalse() {
+        var group = shapeGroup("[region]");
+        var first = signEntry(0, 64, 0, "[region]", "Plot", "d1", 1000L);
+        var second = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var third = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
+        var fourth = signEntry(3, 64, 0, "[region]", "Plot", "d4", 4000L);
+        var newRep = rep(fourth, group);
+
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(first, second, third, fourth), fourth.key(), null, newRep, actionFactory(), false);
+
+        var set = assertInstanceOf(SetShapeMarkerAction.class, action);
+        assertTrue(!set.isFirstAppearance());
+        assertEquals(4, set.getPoints().size());
+    }
+
+    @Test
+    void shapeToNoneDroppingToTwoRemainingMembersDispatchesRemoveShape() {
+        var group = shapeGroup("[region]");
+        var departing = signEntry(0, 64, 0, "[region]", "Plot", "d1", 1000L);
+        var remaining1 = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var remaining2 = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
+        var oldRep = rep(departing, group);
+
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2), departing.key(), oldRep, null, actionFactory(), false);
+
+        assertInstanceOf(RemoveShapeMarkerAction.class, action);
+    }
+
+    @Test
+    void shapeToNoneDroppingToOneOrZeroRemainingMembersIsNoOp() {
+        var group = shapeGroup("[region]");
+        var departing = signEntry(0, 64, 0, "[region]", "Plot", "d1", 1000L);
+        var remaining = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var oldRep = rep(departing, group);
+
+        var actionWithOneRemaining = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining), departing.key(), oldRep, null, actionFactory(), false);
+        var actionWithNoneRemaining = SignTransitionResolver.computeTransitionAction(() -> List.of(), departing.key(), oldRep, null, actionFactory(), false);
+
+        assertNull(actionWithOneRemaining);
+        assertNull(actionWithNoneRemaining);
+    }
+
+    @Test
+    void shapeToNoneWithThreeOrMoreRemainingDispatchesRefreshedSet() {
+        var group = shapeGroup("[region]");
+        var departing = signEntry(0, 64, 0, "[region]", "Plot", "d1", 1000L);
+        var remaining1 = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var remaining2 = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
+        var remaining3 = signEntry(3, 64, 0, "[region]", "Plot", "d4", 4000L);
+        var oldRep = rep(departing, group);
+
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2, remaining3), departing.key(), oldRep, null, actionFactory(), false);
+
+        var set = assertInstanceOf(SetShapeMarkerAction.class, action);
+        assertEquals(3, set.getPoints().size());
+        assertEquals("Plot", set.getDetail());
+    }
+
+    @Test
+    void shapeToShapeSameGroupAndLabelDetailUnchangedIsNoOp() {
+        var group = shapeGroup("[region]");
+        var self = signEntry(0, 64, 0, "[region]", "Plot", "detail", 1000L);
+        var other1 = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var other2 = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
+        var oldRep = rep(self, group);
+        var newRep = rep(self, group);
+
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(self, other1, other2), self.key(), oldRep, newRep, actionFactory(), false);
+
+        assertNull(action);
+    }
+
+    @Test
+    void shapeToShapeSameGroupAndLabelDetailChangedDispatchesSetWithFirstAppearanceFalse() {
+        var group = shapeGroup("[region]");
+        var oldEntry = signEntry(0, 64, 0, "[region]", "Plot", "old detail", 1000L);
+        var newEntry = signEntry(0, 64, 0, "[region]", "Plot", "new detail", 1000L);
+        var other1 = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var other2 = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
+        var oldRep = rep(oldEntry, group);
+        var newRep = rep(newEntry, group);
+
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(newEntry, other1, other2), newEntry.key(), oldRep, newRep, actionFactory(), false);
+
+        var set = assertInstanceOf(SetShapeMarkerAction.class, action);
+        assertTrue(!set.isFirstAppearance());
+    }
+
+    @Test
+    void shapeToShapeSameGroupAndLabelDetailUnchangedOnReloadDispatchesSet() {
+        var group = shapeGroup("[region]");
+        var self = signEntry(0, 64, 0, "[region]", "Plot", "detail", 1000L);
+        var other1 = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var other2 = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
+        var oldRep = rep(self, group);
+        var newRep = rep(self, group);
+
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(self, other1, other2), self.key(), oldRep, newRep, actionFactory(), true);
+
+        var set = assertInstanceOf(SetShapeMarkerAction.class, action);
+        assertEquals(3, set.getPoints().size());
+        assertEquals("Plot", set.getDetail());
+    }
+
+    @Test
+    void shapeToShapeDifferentGroupBundlesLeaveAndJoin() {
+        var oldGroup = shapeGroup("[regionA]");
+        var newGroup = shapeGroup("[regionB]");
+        var otherOldGroupMember1 = signEntry(8, 64, 8, "[regionA]", "OldLabel", "d", 400L);
+        var otherOldGroupMember2 = signEntry(9, 64, 9, "[regionA]", "OldLabel", "d", 500L);
+        var movedEntry = signEntry(0, 64, 0, "[regionB]", "NewLabel", "d", 1000L);
+        var otherNewGroupMember1 = signEntry(1, 64, 0, "[regionB]", "NewLabel", "d2", 2000L);
+        var otherNewGroupMember2 = signEntry(2, 64, 0, "[regionB]", "NewLabel", "d3", 3000L);
+        var oldRep = rep(signEntry(0, 64, 0, "[regionA]", "OldLabel", "d", 1000L), oldGroup);
+        var newRep = rep(movedEntry, newGroup);
+
+        var allSigns = List.of(otherOldGroupMember1, otherOldGroupMember2, movedEntry, otherNewGroupMember1, otherNewGroupMember2);
+        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), false);
+
+        var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
+        assertEquals(2, transition.effects().size());
+        assertInstanceOf(RemoveShapeMarkerAction.class, transition.effects().get(0));
+        var join = assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(1));
+        assertEquals(3, join.getPoints().size());
+    }
+
+    // --- POI<->SHAPE and LINE<->SHAPE type flips (both directions) ---
+
+    @Test
+    void poiToShapeBundlesRemovePoiAndSetShape() {
+        var poi = poiGroup("[poi]");
+        var shape = shapeGroup("[region]");
+        var movedEntry = signEntry(0, 64, 0, "[region]", "Plot", "d", 1000L);
+        var otherMember1 = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var otherMember2 = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
+        var oldRep = rep(signEntry(0, 64, 0, "[poi]", "Shop", "d", 1000L), poi);
+        var newRep = rep(movedEntry, shape);
+
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(movedEntry, otherMember1, otherMember2), movedEntry.key(), oldRep, newRep, actionFactory(), false);
+
+        var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
+        assertEquals(2, transition.effects().size());
+        assertInstanceOf(RemoveMarkerAction.class, transition.effects().get(0));
+        assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(1));
+    }
+
+    @Test
+    void shapeToPoiBundlesSetShapeAndAddPoi() {
+        var shape = shapeGroup("[region]");
+        var poi = poiGroup("[poi]");
+        var departing = signEntry(0, 64, 0, "[region]", "Plot", "d", 1000L);
+        var remaining1 = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var remaining2 = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
+        var remaining3 = signEntry(3, 64, 0, "[region]", "Plot", "d4", 4000L);
+        var movedEntry = signEntry(0, 64, 0, "[poi]", "Shop", "d", 1000L);
+        var oldRep = rep(departing, shape);
+        var newRep = rep(movedEntry, poi);
+
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2, remaining3, movedEntry), movedEntry.key(), oldRep, newRep, actionFactory(), false);
+
+        var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
+        assertEquals(2, transition.effects().size());
+        var leave = assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(0));
+        assertEquals(3, leave.getPoints().size());
+        assertInstanceOf(AddMarkerAction.class, transition.effects().get(1));
+    }
+
+    @Test
+    void lineToShapeBundlesRemoveLineAndSetShape() {
+        var line = lineGroup("[trail]");
+        var shape = shapeGroup("[region]");
+        var departingLineMember = signEntry(9, 64, 9, "[trail]", "Ridge", "d", 500L);
+        var movedEntry = signEntry(0, 64, 0, "[region]", "Plot", "d", 1000L);
+        var otherMember1 = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var otherMember2 = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
+        var oldRep = rep(signEntry(0, 64, 0, "[trail]", "Ridge", "d", 1000L), line);
+        var newRep = rep(movedEntry, shape);
+
+        var allSigns = List.of(departingLineMember, movedEntry, otherMember1, otherMember2);
+        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), false);
+
+        var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
+        assertEquals(2, transition.effects().size());
+        assertInstanceOf(RemoveLineMarkerAction.class, transition.effects().get(0));
+        assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(1));
+    }
+
+    @Test
+    void shapeToLineBundlesRemoveShapeAndSetLine() {
+        var shape = shapeGroup("[region]");
+        var line = lineGroup("[trail]");
+        var departingShapeMember1 = signEntry(8, 64, 8, "[region]", "Plot", "d", 400L);
+        var departingShapeMember2 = signEntry(9, 64, 9, "[region]", "Plot", "d", 500L);
+        var movedEntry = signEntry(0, 64, 0, "[trail]", "Ridge", "d", 1000L);
+        var otherLineMember = signEntry(1, 64, 0, "[trail]", "Ridge", "d2", 2000L);
+        var oldRep = rep(signEntry(0, 64, 0, "[region]", "Plot", "d", 1000L), shape);
+        var newRep = rep(movedEntry, line);
+
+        var allSigns = List.of(departingShapeMember1, departingShapeMember2, movedEntry, otherLineMember);
+        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), false);
+
+        var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
+        assertEquals(2, transition.effects().size());
+        assertInstanceOf(RemoveShapeMarkerAction.class, transition.effects().get(0));
+        assertInstanceOf(SetLineMarkerAction.class, transition.effects().get(1));
+    }
+
+    // --- isReload variants for POI<->SHAPE and LINE<->SHAPE flips, mirroring the existing POI/LINE reload coverage ---
+
+    @Test
+    void poiToShapeOnReloadStillBundlesRemovePoiAndSetShape() {
+        var poi = poiGroup("[poi]");
+        var shape = shapeGroup("[region]");
+        var movedEntry = signEntry(0, 64, 0, "[region]", "Plot", "d", 1000L);
+        var otherMember1 = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var otherMember2 = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
+        var oldRep = rep(signEntry(0, 64, 0, "[poi]", "Shop", "d", 1000L), poi);
+        var newRep = rep(movedEntry, shape);
+
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(movedEntry, otherMember1, otherMember2), movedEntry.key(), oldRep, newRep, actionFactory(), true);
+
+        var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
+        assertEquals(2, transition.effects().size());
+        assertInstanceOf(RemoveMarkerAction.class, transition.effects().get(0));
+        assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(1));
+    }
+
+    @Test
+    void shapeToPoiOnReloadStillBundlesSetShapeAndAddPoi() {
+        var shape = shapeGroup("[region]");
+        var poi = poiGroup("[poi]");
+        var departing = signEntry(0, 64, 0, "[region]", "Plot", "d", 1000L);
+        var remaining1 = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var remaining2 = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
+        var remaining3 = signEntry(3, 64, 0, "[region]", "Plot", "d4", 4000L);
+        var movedEntry = signEntry(0, 64, 0, "[poi]", "Shop", "d", 1000L);
+        var oldRep = rep(departing, shape);
+        var newRep = rep(movedEntry, poi);
+
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2, remaining3, movedEntry), movedEntry.key(), oldRep, newRep, actionFactory(), true);
+
+        var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
+        assertEquals(2, transition.effects().size());
+        var leave = assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(0));
+        assertEquals(3, leave.getPoints().size());
+        assertInstanceOf(AddMarkerAction.class, transition.effects().get(1));
+    }
+
+    @Test
+    void lineToShapeOnReloadStillBundlesRemoveLineAndSetShape() {
+        var line = lineGroup("[trail]");
+        var shape = shapeGroup("[region]");
+        var departingLineMember = signEntry(9, 64, 9, "[trail]", "Ridge", "d", 500L);
+        var movedEntry = signEntry(0, 64, 0, "[region]", "Plot", "d", 1000L);
+        var otherMember1 = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var otherMember2 = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
+        var oldRep = rep(signEntry(0, 64, 0, "[trail]", "Ridge", "d", 1000L), line);
+        var newRep = rep(movedEntry, shape);
+
+        var allSigns = List.of(departingLineMember, movedEntry, otherMember1, otherMember2);
+        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), true);
+
+        var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
+        assertEquals(2, transition.effects().size());
+        assertInstanceOf(RemoveLineMarkerAction.class, transition.effects().get(0));
+        assertInstanceOf(SetShapeMarkerAction.class, transition.effects().get(1));
+    }
+
+    @Test
+    void shapeToLineOnReloadStillBundlesRemoveShapeAndSetLine() {
+        var shape = shapeGroup("[region]");
+        var line = lineGroup("[trail]");
+        var departingShapeMember1 = signEntry(8, 64, 8, "[region]", "Plot", "d", 400L);
+        var departingShapeMember2 = signEntry(9, 64, 9, "[region]", "Plot", "d", 500L);
+        var movedEntry = signEntry(0, 64, 0, "[trail]", "Ridge", "d", 1000L);
+        var otherLineMember = signEntry(1, 64, 0, "[trail]", "Ridge", "d2", 2000L);
+        var oldRep = rep(signEntry(0, 64, 0, "[region]", "Plot", "d", 1000L), shape);
+        var newRep = rep(movedEntry, line);
+
+        var allSigns = List.of(departingShapeMember1, departingShapeMember2, movedEntry, otherLineMember);
+        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), true);
+
+        var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
+        assertEquals(2, transition.effects().size());
+        assertInstanceOf(RemoveShapeMarkerAction.class, transition.effects().get(0));
+        assertInstanceOf(SetLineMarkerAction.class, transition.effects().get(1));
     }
 }

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolverTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolverTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // Table-driven coverage of SignTransitionResolver.computeTransitionAction, one test per row/sub-branch
-// of the transition table in .scratch/line-markers/spec.md §6.
+// of the transition table in .scratch/line-markers/spec.md Â§6.
 class SignTransitionResolverTest {
 
     private static final String MAP = "minecraft:overworld";
@@ -68,7 +68,7 @@ class SignTransitionResolverTest {
     void noneToNoneIsNoOp() {
         var key = new SignEntryKey(0, 64, 0, MAP);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(), key, null, null, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(), key, null, null, actionFactory(), false, Map.of());
 
         assertNull(action);
     }
@@ -89,7 +89,7 @@ class SignTransitionResolverTest {
         var entry = signEntry(0, 64, 0, "[poi]", "Shop", "detail", 1000L);
         var newRep = rep(entry, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(entry), entry.key(), null, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(entry), entry.key(), null, newRep, actionFactory(), false, Map.of(group.prefix(), group));
 
         var add = assertInstanceOf(AddMarkerAction.class, action);
         assertEquals("Shop", add.getLabel());
@@ -102,7 +102,7 @@ class SignTransitionResolverTest {
         var entry = signEntry(0, 64, 0, "[trail]", "Ridge", "detail", 1000L);
         var newRep = rep(entry, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(entry), entry.key(), null, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(entry), entry.key(), null, newRep, actionFactory(), false, Map.of(group.prefix(), group));
 
         assertNull(action);
     }
@@ -114,7 +114,7 @@ class SignTransitionResolverTest {
         var second = signEntry(1, 64, 0, "[trail]", "Ridge", "d2", 2000L);
         var newRep = rep(second, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(first, second), second.key(), null, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(first, second), second.key(), null, newRep, actionFactory(), false, Map.of(group.prefix(), group));
 
         var set = assertInstanceOf(SetLineMarkerAction.class, action);
         assertTrue(set.isFirstAppearance());
@@ -130,7 +130,7 @@ class SignTransitionResolverTest {
         var third = signEntry(2, 64, 0, "[trail]", "Ridge", "d3", 3000L);
         var newRep = rep(third, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(first, second, third), third.key(), null, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(first, second, third), third.key(), null, newRep, actionFactory(), false, Map.of(group.prefix(), group));
 
         var set = assertInstanceOf(SetLineMarkerAction.class, action);
         assertTrue(!set.isFirstAppearance());
@@ -144,7 +144,7 @@ class SignTransitionResolverTest {
         var entry = signEntry(0, 64, 0, "[poi]", "Shop", "detail", 1000L);
         var oldRep = rep(entry, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(), entry.key(), oldRep, null, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(), entry.key(), oldRep, null, actionFactory(), false, Map.of(group.prefix(), group));
 
         assertInstanceOf(RemoveMarkerAction.class, action);
     }
@@ -156,7 +156,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(entry, group);
         var newRep = rep(entry, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(entry), entry.key(), oldRep, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(entry), entry.key(), oldRep, newRep, actionFactory(), false, Map.of(group.prefix(), group));
 
         assertNull(action);
     }
@@ -168,7 +168,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(entry, group);
         var newRep = rep(entry, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(entry), entry.key(), oldRep, newRep, actionFactory(), true);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(entry), entry.key(), oldRep, newRep, actionFactory(), true, Map.of(group.prefix(), group));
 
         var add = assertInstanceOf(AddMarkerAction.class, action);
         assertEquals("Shop", add.getLabel());
@@ -183,7 +183,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(oldEntry, group);
         var newRep = rep(newEntry, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(newEntry), newEntry.key(), oldRep, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(newEntry), newEntry.key(), oldRep, newRep, actionFactory(), false, Map.of(group.prefix(), group));
 
         var update = assertInstanceOf(UpdateMarkerAction.class, action);
         assertEquals("new detail", update.getNewDetails());
@@ -198,7 +198,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(oldEntry, oldGroup);
         var newRep = rep(entry, newGroup);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(entry), entry.key(), oldRep, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(entry), entry.key(), oldRep, newRep, actionFactory(), false, Map.of(oldGroup.prefix(), oldGroup, newGroup.prefix(), newGroup));
 
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
@@ -213,7 +213,7 @@ class SignTransitionResolverTest {
         var remaining = signEntry(1, 64, 0, "[trail]", "Ridge", "d2", 2000L);
         var oldRep = rep(departing, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining), departing.key(), oldRep, null, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining), departing.key(), oldRep, null, actionFactory(), false, Map.of(group.prefix(), group));
 
         assertInstanceOf(RemoveLineMarkerAction.class, action);
     }
@@ -224,7 +224,7 @@ class SignTransitionResolverTest {
         var departing = signEntry(0, 64, 0, "[trail]", "Ridge", "d1", 1000L);
         var oldRep = rep(departing, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(), departing.key(), oldRep, null, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(), departing.key(), oldRep, null, actionFactory(), false, Map.of(group.prefix(), group));
 
         assertNull(action);
     }
@@ -237,7 +237,7 @@ class SignTransitionResolverTest {
         var remaining2 = signEntry(2, 64, 0, "[trail]", "Ridge", "d3", 3000L);
         var oldRep = rep(departing, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2), departing.key(), oldRep, null, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2), departing.key(), oldRep, null, actionFactory(), false, Map.of(group.prefix(), group));
 
         var set = assertInstanceOf(SetLineMarkerAction.class, action);
         assertEquals(2, set.getPoints().size());
@@ -252,7 +252,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(self, group);
         var newRep = rep(self, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(self, other), self.key(), oldRep, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(self, other), self.key(), oldRep, newRep, actionFactory(), false, Map.of(group.prefix(), group));
 
         assertNull(action);
     }
@@ -266,7 +266,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(oldEntry, group);
         var newRep = rep(newEntry, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(newEntry, other), newEntry.key(), oldRep, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(newEntry, other), newEntry.key(), oldRep, newRep, actionFactory(), false, Map.of(group.prefix(), group));
 
         var set = assertInstanceOf(SetLineMarkerAction.class, action);
         assertTrue(!set.isFirstAppearance());
@@ -280,7 +280,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(self, group);
         var newRep = rep(self, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(self, other), self.key(), oldRep, newRep, actionFactory(), true);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(self, other), self.key(), oldRep, newRep, actionFactory(), true, Map.of(group.prefix(), group));
 
         var set = assertInstanceOf(SetLineMarkerAction.class, action);
         assertEquals(2, set.getPoints().size());
@@ -298,7 +298,7 @@ class SignTransitionResolverTest {
         var newRep = rep(movedEntry, newGroup);
 
         var allSigns = List.of(otherOldGroupMember, movedEntry, otherNewGroupMember);
-        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), false, Map.of(oldGroup.prefix(), oldGroup, newGroup.prefix(), newGroup));
 
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
@@ -316,7 +316,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(signEntry(0, 64, 0, "[poi]", "Shop", "d", 1000L), poi);
         var newRep = rep(movedEntry, line);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(movedEntry, otherLineMember), movedEntry.key(), oldRep, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(movedEntry, otherLineMember), movedEntry.key(), oldRep, newRep, actionFactory(), false, Map.of(poi.prefix(), poi, line.prefix(), line));
 
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
@@ -335,7 +335,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(departing, line);
         var newRep = rep(movedEntry, poi);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2, movedEntry), movedEntry.key(), oldRep, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2, movedEntry), movedEntry.key(), oldRep, newRep, actionFactory(), false, Map.of(line.prefix(), line, poi.prefix(), poi));
 
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
@@ -353,7 +353,7 @@ class SignTransitionResolverTest {
         var second = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
         var newRep = rep(second, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(first, second), second.key(), null, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(first, second), second.key(), null, newRep, actionFactory(), false, Map.of(group.prefix(), group));
 
         assertNull(action);
     }
@@ -366,7 +366,7 @@ class SignTransitionResolverTest {
         var third = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
         var newRep = rep(third, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(first, second, third), third.key(), null, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(first, second, third), third.key(), null, newRep, actionFactory(), false, Map.of(group.prefix(), group));
 
         var set = assertInstanceOf(SetShapeMarkerAction.class, action);
         assertTrue(set.isFirstAppearance());
@@ -383,7 +383,7 @@ class SignTransitionResolverTest {
         var fourth = signEntry(3, 64, 0, "[region]", "Plot", "d4", 4000L);
         var newRep = rep(fourth, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(first, second, third, fourth), fourth.key(), null, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(first, second, third, fourth), fourth.key(), null, newRep, actionFactory(), false, Map.of(group.prefix(), group));
 
         var set = assertInstanceOf(SetShapeMarkerAction.class, action);
         assertTrue(!set.isFirstAppearance());
@@ -398,7 +398,7 @@ class SignTransitionResolverTest {
         var remaining2 = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
         var oldRep = rep(departing, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2), departing.key(), oldRep, null, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2), departing.key(), oldRep, null, actionFactory(), false, Map.of(group.prefix(), group));
 
         assertInstanceOf(RemoveShapeMarkerAction.class, action);
     }
@@ -410,8 +410,8 @@ class SignTransitionResolverTest {
         var remaining = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
         var oldRep = rep(departing, group);
 
-        var actionWithOneRemaining = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining), departing.key(), oldRep, null, actionFactory(), false);
-        var actionWithNoneRemaining = SignTransitionResolver.computeTransitionAction(() -> List.of(), departing.key(), oldRep, null, actionFactory(), false);
+        var actionWithOneRemaining = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining), departing.key(), oldRep, null, actionFactory(), false, Map.of(group.prefix(), group));
+        var actionWithNoneRemaining = SignTransitionResolver.computeTransitionAction(() -> List.of(), departing.key(), oldRep, null, actionFactory(), false, Map.of(group.prefix(), group));
 
         assertNull(actionWithOneRemaining);
         assertNull(actionWithNoneRemaining);
@@ -426,7 +426,7 @@ class SignTransitionResolverTest {
         var remaining3 = signEntry(3, 64, 0, "[region]", "Plot", "d4", 4000L);
         var oldRep = rep(departing, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2, remaining3), departing.key(), oldRep, null, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2, remaining3), departing.key(), oldRep, null, actionFactory(), false, Map.of(group.prefix(), group));
 
         var set = assertInstanceOf(SetShapeMarkerAction.class, action);
         assertEquals(3, set.getPoints().size());
@@ -442,7 +442,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(self, group);
         var newRep = rep(self, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(self, other1, other2), self.key(), oldRep, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(self, other1, other2), self.key(), oldRep, newRep, actionFactory(), false, Map.of(group.prefix(), group));
 
         assertNull(action);
     }
@@ -457,7 +457,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(oldEntry, group);
         var newRep = rep(newEntry, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(newEntry, other1, other2), newEntry.key(), oldRep, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(newEntry, other1, other2), newEntry.key(), oldRep, newRep, actionFactory(), false, Map.of(group.prefix(), group));
 
         var set = assertInstanceOf(SetShapeMarkerAction.class, action);
         assertTrue(!set.isFirstAppearance());
@@ -472,7 +472,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(self, group);
         var newRep = rep(self, group);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(self, other1, other2), self.key(), oldRep, newRep, actionFactory(), true);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(self, other1, other2), self.key(), oldRep, newRep, actionFactory(), true, Map.of(group.prefix(), group));
 
         var set = assertInstanceOf(SetShapeMarkerAction.class, action);
         assertEquals(3, set.getPoints().size());
@@ -492,7 +492,7 @@ class SignTransitionResolverTest {
         var newRep = rep(movedEntry, newGroup);
 
         var allSigns = List.of(otherOldGroupMember1, otherOldGroupMember2, movedEntry, otherNewGroupMember1, otherNewGroupMember2);
-        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), false, Map.of(oldGroup.prefix(), oldGroup, newGroup.prefix(), newGroup));
 
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
@@ -513,7 +513,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(signEntry(0, 64, 0, "[poi]", "Shop", "d", 1000L), poi);
         var newRep = rep(movedEntry, shape);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(movedEntry, otherMember1, otherMember2), movedEntry.key(), oldRep, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(movedEntry, otherMember1, otherMember2), movedEntry.key(), oldRep, newRep, actionFactory(), false, Map.of(poi.prefix(), poi, shape.prefix(), shape));
 
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
@@ -534,7 +534,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(departing, shape);
         var newRep = rep(movedEntry, poi);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2, remaining3, movedEntry), movedEntry.key(), oldRep, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2, remaining3, movedEntry), movedEntry.key(), oldRep, newRep, actionFactory(), false, Map.of(shape.prefix(), shape, poi.prefix(), poi));
 
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
@@ -555,7 +555,7 @@ class SignTransitionResolverTest {
         var newRep = rep(movedEntry, shape);
 
         var allSigns = List.of(departingLineMember, movedEntry, otherMember1, otherMember2);
-        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), false, Map.of(line.prefix(), line, shape.prefix(), shape));
 
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
@@ -576,7 +576,7 @@ class SignTransitionResolverTest {
         var newRep = rep(movedEntry, line);
 
         var allSigns = List.of(departingShapeMember1, departingShapeMember2, movedEntry, otherLineMember);
-        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), false);
+        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), false, Map.of(shape.prefix(), shape, line.prefix(), line));
 
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
@@ -596,7 +596,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(signEntry(0, 64, 0, "[poi]", "Shop", "d", 1000L), poi);
         var newRep = rep(movedEntry, shape);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(movedEntry, otherMember1, otherMember2), movedEntry.key(), oldRep, newRep, actionFactory(), true);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(movedEntry, otherMember1, otherMember2), movedEntry.key(), oldRep, newRep, actionFactory(), true, Map.of(poi.prefix(), poi, shape.prefix(), shape));
 
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
@@ -617,7 +617,7 @@ class SignTransitionResolverTest {
         var oldRep = rep(departing, shape);
         var newRep = rep(movedEntry, poi);
 
-        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2, remaining3, movedEntry), movedEntry.key(), oldRep, newRep, actionFactory(), true);
+        var action = SignTransitionResolver.computeTransitionAction(() -> List.of(remaining1, remaining2, remaining3, movedEntry), movedEntry.key(), oldRep, newRep, actionFactory(), true, Map.of(shape.prefix(), shape, poi.prefix(), poi));
 
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
@@ -638,7 +638,7 @@ class SignTransitionResolverTest {
         var newRep = rep(movedEntry, shape);
 
         var allSigns = List.of(departingLineMember, movedEntry, otherMember1, otherMember2);
-        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), true);
+        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), true, Map.of(line.prefix(), line, shape.prefix(), shape));
 
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
@@ -659,11 +659,35 @@ class SignTransitionResolverTest {
         var newRep = rep(movedEntry, line);
 
         var allSigns = List.of(departingShapeMember1, departingShapeMember2, movedEntry, otherLineMember);
-        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), true);
+        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, movedEntry.key(), oldRep, newRep, actionFactory(), true, Map.of(shape.prefix(), shape, line.prefix(), line));
 
         var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
         assertEquals(2, transition.effects().size());
         assertInstanceOf(RemoveShapeMarkerAction.class, transition.effects().get(0));
         assertInstanceOf(SetLineMarkerAction.class, transition.effects().get(1));
+    }
+
+    // Regression for agent-context/reviews/review-2026-08-20.md: a reload where a group's *type* flips
+    // (same prefix, SHAPE -> POI) while all its signs keep the same prefix/label. Every member undergoes
+    // this transition at once, so the shared prefix/label still "matches" 3+ signs in the reparsed cache -
+    // shapeLeaveAction must not mistake that for an ordinary member still active under a live SHAPE group
+    // and recompute the old shape instead of retiring it.
+    @Test
+    void shapeToPoiConfigOnlyTypeFlipOnReloadRemovesShapeInsteadOfRecomputing() {
+        var shape = shapeGroup("[region]");
+        var poi = poiGroup("[region]");
+        var first = signEntry(0, 64, 0, "[region]", "Plot", "d1", 1000L);
+        var second = signEntry(1, 64, 0, "[region]", "Plot", "d2", 2000L);
+        var third = signEntry(2, 64, 0, "[region]", "Plot", "d3", 3000L);
+        var oldRep = rep(first, shape);
+        var newRep = rep(first, poi);
+
+        var allSigns = List.of(first, second, third);
+        var action = SignTransitionResolver.computeTransitionAction(() -> allSigns, first.key(), oldRep, newRep, actionFactory(), true, Map.of(poi.prefix(), poi));
+
+        var transition = assertInstanceOf(GroupTransitionMarkerAction.class, action);
+        assertEquals(2, transition.effects().size());
+        assertInstanceOf(RemoveShapeMarkerAction.class, transition.effects().get(0));
+        assertInstanceOf(AddMarkerAction.class, transition.effects().get(1));
     }
 }

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/LegacySignFileMigratorTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/LegacySignFileMigratorTest.java
@@ -65,7 +65,7 @@ class LegacySignFileMigratorTest {
         var storageRoot = tempDir.resolve("storage");
         var poiGroup = new MarkerGroup(
                 "[poi]", MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI,
-                "Points of Interest", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF");
+                "Points of Interest", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
 
         // Already-namespaced dimension string: Version1SignEntryLoader's legacy-shorthand ("overworld"/"nether"/
         // "end") normalization branch reaches into net.minecraft.world.level.Level's static constants, which

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/Version1SignEntryLoaderTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/Version1SignEntryLoaderTest.java
@@ -26,7 +26,7 @@ class Version1SignEntryLoaderTest {
     private static final Gson GSON = new Gson();
     private static final MarkerGroup[] POI_GROUP = {
             new MarkerGroup("[poi]", MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI,
-                    "[poi]", null, 0, 0, false, 0, 0, 2, "#FF0000FF")
+                    "[poi]", null, 0, 0, false, 0, 0, 2, "#FF0000FF", "#FF000033")
     };
 
     private static String load(Path tempDir, String legacyDimension) throws IOException {

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/Version3ConverterTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/Version3ConverterTest.java
@@ -19,7 +19,7 @@ class Version3ConverterTest {
     private static MarkerGroup poiGroup(String prefix) {
         return new MarkerGroup(
                 prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, prefix, null, 0, 0, false, 0, 0,
-                2, "#FF0000FF");
+                2, "#FF0000FF", "#FF000033");
     }
 
     private static SignEntryV2 entryWith(SignLinesParseResultV2 front, SignLinesParseResultV2 back) {

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/VersionedFileSignEntryLoaderTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/VersionedFileSignEntryLoaderTest.java
@@ -37,7 +37,7 @@ class VersionedFileSignEntryLoaderTest {
     private static MarkerGroup poiGroup(String prefix) {
         return new MarkerGroup(
                 prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, prefix, null, 0, 0, false, 0, 0,
-                2, "#FF0000FF");
+                2, "#FF0000FF", "#FF000033");
     }
 
     @Test


### PR DESCRIPTION
## What

Adds a `SHAPE` marker group type: signs sharing a group's prefix and label form a closed, filled polygon marker on BlueMap once 3+ signs exist, alongside the existing `POI` and `LINE` types.

## Why

Issue #8 requests polygon/region markers (e.g. claim boundaries, zones) in addition to the existing point and line markers.

## Changes

- `MarkerGroupType`: add `SHAPE` alongside `POI/LINE`
- `MarkerGroup`/config loading: add `fillColor` field (`SHAPE`-only, translucent-red default); field-applicability warnings now cover all three types instead of just `POI/LINE`
- `ShapeGroupResolver`: resolves signs into shape membership (mirrors `LineGroupResolver`), reusing the shared prefix/label grouping key
- `ShapeMarkerIdentifier`, `SetShapeMarkerAction`, `RemoveShapeMarkerAction`: build/dispatch/remove BlueMap `Shape` markers; wired into `ActionFactory` and `BlueMapAPIConnector` (`processMarkerAction`/`logProcessingMessage` switches)
- `SignTransitionResolver`: transition table extended to cover `SHAPE` add/update/remove and type-flip transitions (`POI`↔`SHAPE`, `LINE`↔`SHAPE`)
- Reduced logging chatter in `BlueMapAPIConnector` from earlier testing
- `README.md`: document `SHAPE` type, `fillColor`, and a `[region]` example group
- `CONTEXT.md` and two new ADRs (`0001-shape-points-insertion-order-no-validation`, `0002-shape-duplicates-line-pattern`) documenting shape marker design decisions
- Spec and issue breakdown under `.scratch/shape-markers/`
- Extensive new/updated unit tests: `ShapeGroupResolverTest`, `SignTransitionResolverTest` (shape transitions), `ActionFactoryTest`, `ConfigProviderTest`

## Testing

- `./gradlew test` — unit tests cover `ShapeGroupResolver`, `SignTransitionResolver` shape transitions, `ActionFactory`, and config parsing/warnings for `fillColor`
- `./gradlew runServer` — manually place 3+ signs with a shared `[region]`-style prefix/label and verify a filled polygon marker appears/updates/removes as signs are added, edited, or removed, and that flipping a group's `type` between `POI`/`LINE`/`SHAPE` doesn't orphan markers