### PR TITLE
#197 Marker polish: sorting, toggleable, depth-test, style classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ restart alone does not trigger the upgrade sweep (only a genuine BlueMap disable
 
 `MarkerGroup` (record: prefix, matchType, type, name, icon, offsetX/Y, defaultHidden, minDistance/maxDistance,
 lineWidth, lineColor, fillColor, sorting, toggleable, depthTest, cssClasses) is the unit of configuration described
-in `README.md`. `type` (`MarkerGroupType`: `POI` or `LINE`) picks which kind of marker the group's signs produce;
+in `README.md`. `type` (`MarkerGroupType`: `POI`, `LINE`, or `SHAPE`) picks which kind of marker the group's signs produce;
 `lineWidth`/`lineColor` only apply to `LINE` groups (setting them on a `POI` group is a warning, not an error).
 `sorting`/`toggleable` are thin BlueMap `MarkerSet` passthroughs (menu order, hideability) that apply to every group
 type; `depthTest` (terrain occlusion) is `LINE`/`SHAPE`-only and `cssClasses` (custom.css hooks) is `POI`-only, each

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,9 +126,13 @@ restart alone does not trigger the upgrade sweep (only a genuine BlueMap disable
 ### Marker groups and config
 
 `MarkerGroup` (record: prefix, matchType, type, name, icon, offsetX/Y, defaultHidden, minDistance/maxDistance,
-lineWidth, lineColor) is the unit of configuration described in `README.md`. `type` (`MarkerGroupType`: `POI` or
-`LINE`) picks which kind of marker the group's signs produce; `lineWidth`/`lineColor` only apply to `LINE` groups
-(setting them on a `POI` group is a warning, not an error). `ConfigManager` lazily loads a singleton `BMSMConfigV2`
+lineWidth, lineColor, fillColor, sorting, toggleable, depthTest, cssClasses) is the unit of configuration described
+in `README.md`. `type` (`MarkerGroupType`: `POI` or `LINE`) picks which kind of marker the group's signs produce;
+`lineWidth`/`lineColor` only apply to `LINE` groups (setting them on a `POI` group is a warning, not an error).
+`sorting`/`toggleable` are thin BlueMap `MarkerSet` passthroughs (menu order, hideability) that apply to every group
+type; `depthTest` (terrain occlusion) is `LINE`/`SHAPE`-only and `cssClasses` (custom.css hooks) is `POI`-only, each
+resolved in `ConfigProvider` and wired into the corresponding BlueMap builder call in `BlueMapAPIConnector`.
+`ConfigManager` lazily loads a singleton `BMSMConfigV2`
 via `ConfigProvider` from `config/bluemapsignmarkers/BMSM-Core.json`, creating sane defaults (a single `[poi]` group)
 if the file is missing or fails to load. `SignLinesParser` matches sign text against groups using either
 `STARTS_WITH` or `REGEX` (see `MarkerGroupMatchType`) — note that `REGEX` uses `String.matches(...)`, which requires

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ restart alone does not trigger the upgrade sweep (only a genuine BlueMap disable
 `MarkerGroup` (record: prefix, matchType, type, name, icon, offsetX/Y, defaultHidden, minDistance/maxDistance,
 lineWidth, lineColor, fillColor, sorting, toggleable, depthTest, cssClasses) is the unit of configuration described
 in `README.md`. `type` (`MarkerGroupType`: `POI`, `LINE`, or `SHAPE`) picks which kind of marker the group's signs produce;
-`lineWidth`/`lineColor` only apply to `LINE` groups (setting them on a `POI` group is a warning, not an error).
+`lineWidth`/`lineColor` apply to `LINE`/`SHAPE` groups (setting them on a `POI` group is a warning, not an error).
 `sorting`/`toggleable` are thin BlueMap `MarkerSet` passthroughs (menu order, hideability) that apply to every group
 type; `depthTest` (terrain occlusion) is `LINE`/`SHAPE`-only and `cssClasses` (custom.css hooks) is `POI`-only, each
 resolved in `ConfigProvider` and wired into the corresponding BlueMap builder call in `BlueMapAPIConnector`.

--- a/README.md
+++ b/README.md
@@ -47,9 +47,14 @@ configuration contains the following options:
 - `lineWidth` - the width in pixels of the line/shape border; optional; default is `2`; `LINE`/`SHAPE` only
 - `lineColor` - the hex color (with alpha) of the line/shape border, e.g. `#FF0000FF`; optional; default is `#FF0000FF`; `LINE`/`SHAPE` only
 - `fillColor` - the hex color (with alpha) of a shape's interior, e.g. `#FF000033`; optional; default is `#FF000033` (translucent red); `SHAPE` only
+- `sorting` - the marker-set's order in the map's layer menu (lower sorts first); optional; default is `0`
+- `toggleable` - whether the marker-set can be hidden/shown by a player at all; optional; default is `true`
+- `depthTest` - whether terrain can occlude the marker (set `false` to keep an underground trail/region visible through terrain); optional; default is `true`; `LINE`/`SHAPE` only
+- `cssClasses` - a list of CSS classes added to the marker element, for styling via BlueMap's `custom.css`; optional; default is an empty list; `POI` only
 
-Setting a field on a group type it doesn't apply to (e.g. `icon` on a `LINE`/`SHAPE` group, or `fillColor` on a
-`POI`/`LINE` group) is not an error; the mod logs a warning and ignores the field.
+Setting a field on a group type it doesn't apply to (e.g. `icon` on a `LINE`/`SHAPE` group, `fillColor` on a
+`POI`/`LINE` group, `depthTest` on a `POI` group, or `cssClasses` on a `LINE`/`SHAPE` group) is not an error; the mod
+logs a warning and ignores the field.
 
 ## Example
 

--- a/agent-context/context/config-and-persistence.md
+++ b/agent-context/context/config-and-persistence.md
@@ -53,9 +53,10 @@ File: `config/bluemapsignmarkers/BMSM-Core.json`. Path is fixed (not per-world) 
      `LoadingMarkerGroupV2` as a raw `JsonElement` rather than `Integer` specifically so a non-integer JSON value
      (a string, an array, an out-of-`int`-range number) falls back to the default with a warning in
      `resolveSorting` instead of failing Gson's parse for the *entire* config; `resolveCssClasses` drops any `null`
-     entries in the list (warning once) rather than propagating them to BlueMap's marker builder. `resolveToggleable`/
-     `resolveDepthTest` are plain null-coalescing (`toggleable == null || toggleable`, same for `depthTest`) since
-     both are simple booleans with no malformed-value case to guard against. This two-model split (`LoadingMarkerGroupV2`
+     entries in the list (warning once) rather than propagating them to BlueMap's marker builder. `resolveToggleable` is plain null-coalescing (`toggleable == null || toggleable`), a simple boolean with no
+     malformed-value case to guard against. `resolveDepthTest` is not: an unset value defaults to `true`, but a
+     configured value is only honored for `LINE`/`SHAPE` groups — for any other type (`POI`) it forces `true`
+     regardless of what was configured, since depth-testing has no effect on a POI marker. This two-model split (`LoadingMarkerGroupV2`
      boxed/nullable vs. `MarkerGroup` primitive) exists so a partially-specified group in user JSON gets these
      explicit defaults rather than Gson silently zeroing missing primitive fields. `validateMarkerGroups` then fails
      fast (`IllegalArgumentException`, caught by the catch-all below) on an empty prefix, a `REGEX` prefix that

--- a/agent-context/context/config-and-persistence.md
+++ b/agent-context/context/config-and-persistence.md
@@ -37,18 +37,25 @@ File: `config/bluemapsignmarkers/BMSM-Core.json`. Path is fixed (not per-world) 
      `core-pipeline.md` §3 — rather than duplicated separately) and convert each `LoadingMarkerGroupV2` to a
      runtime `MarkerGroup` via `convertToLoadedMarkerGroup`, which applies defaults per-field (`matchType` →
      `STARTS_WITH`, `type` → `POI`, `offsetX`/`offsetY` → `0`, `defaultHidden` → `false`, `minDistance` → `0.0`,
-     `maxDistance` → `10000000.0`, `lineWidth` → `2`, `lineColor` → `"#FF0000FF"`, `fillColor` → `"#FF000033"` — the
-     latter three are the `LINE`/`SHAPE`-marker additions, mirroring BlueMap's own `LineMarker`/`ShapeMarker`
-     defaults; `fillColor`'s default is translucent, unlike `lineColor`'s opaque one). `lineWidth`/`lineColor`/
-     `fillColor` each go through their own validating resolver (`resolveLineWidth`/`resolveLineColor`/
-     `resolveFillColor`) rather than a plain null-check default: a non-positive `lineWidth` (`<= 0`) or a
-     `lineColor`/`fillColor` that fails `ColorUtils.isValidHex` (accepts `#RRGGBB`/`#RRGGBBAA`, leading `#`
-     optional — the same shape `ColorUtils.parseHex` accepts) logs a warning naming the group and falls back to the
-     default, instead of the malformed value reaching `ActionFactory`/BlueMap's `LineMarker`/`ShapeMarker`
-     unnoticed (silently caught later only at dispatch time by `ColorUtils.parseHex`'s own fallback).
-     `resolveFillColor` only validates when the group's effective `type` is `SHAPE`; for any other type it returns
-     the raw configured value unvalidated (pass-through — `fillColor` isn't applied for non-`SHAPE` groups anyway).
-     This two-model split (`LoadingMarkerGroupV2`
+     `maxDistance` → `10000000.0`, `lineWidth` → `2`, `lineColor` → `"#FF0000FF"`, `fillColor` → `"#FF000033"`,
+     `sorting` → `0`, `toggleable` → `true`, `depthTest` → `true`, `cssClasses` → `List.of()` — the `lineWidth`/
+     `lineColor`/`fillColor` trio are the `LINE`/`SHAPE`-marker additions, mirroring BlueMap's own `LineMarker`/
+     `ShapeMarker` defaults; `fillColor`'s default is translucent, unlike `lineColor`'s opaque one).
+     `lineWidth`/`lineColor`/`fillColor`/`sorting`/`cssClasses` each go through their own validating resolver
+     (`resolveLineWidth`/`resolveLineColor`/`resolveFillColor`/`resolveSorting`/`resolveCssClasses`) rather than a
+     plain null-check default: a non-positive `lineWidth` (`<= 0`) or a `lineColor`/`fillColor` that fails
+     `ColorUtils.isValidHex` (accepts `#RRGGBB`/`#RRGGBBAA`, leading `#` optional — the same shape
+     `ColorUtils.parseHex` accepts) logs a warning naming the group and falls back to the default, instead of the
+     malformed value reaching `ActionFactory`/BlueMap's `LineMarker`/`ShapeMarker` unnoticed (silently caught later
+     only at dispatch time by `ColorUtils.parseHex`'s own fallback). `resolveFillColor` only validates when the
+     group's effective `type` is `SHAPE`; for any other type it returns the raw configured value unvalidated
+     (pass-through — `fillColor` isn't applied for non-`SHAPE` groups anyway). `sorting` is read off
+     `LoadingMarkerGroupV2` as a raw `JsonElement` rather than `Integer` specifically so a non-integer JSON value
+     (a string, an array, an out-of-`int`-range number) falls back to the default with a warning in
+     `resolveSorting` instead of failing Gson's parse for the *entire* config; `resolveCssClasses` drops any `null`
+     entries in the list (warning once) rather than propagating them to BlueMap's marker builder. `resolveToggleable`/
+     `resolveDepthTest` are plain null-coalescing (`toggleable == null || toggleable`, same for `depthTest`) since
+     both are simple booleans with no malformed-value case to guard against. This two-model split (`LoadingMarkerGroupV2`
      boxed/nullable vs. `MarkerGroup` primitive) exists so a partially-specified group in user JSON gets these
      explicit defaults rather than Gson silently zeroing missing primitive fields. `validateMarkerGroups` then fails
      fast (`IllegalArgumentException`, caught by the catch-all below) on an empty prefix, a `REGEX` prefix that
@@ -56,10 +63,11 @@ File: `config/bluemapsignmarkers/BMSM-Core.json`. Path is fixed (not per-world) 
      downstream in `SignLinesParser`/`SignManager`. A separate, non-fatal pass, `warnOnTypeFieldMismatches`, logs a
      warning (never throws) against the raw `LoadingMarkerGroupV2` (which still distinguishes "field omitted" via
      `null`) for a field set on a type it doesn't apply to: `POI` warns on an explicit `lineWidth`/`lineColor`/
-     `fillColor`; `LINE` warns on an explicit `icon`/`offsetX`/`offsetY`/`fillColor`; `SHAPE` warns on an explicit
-     `icon`/`offsetX`/`offsetY` (but *not* `lineWidth`/`lineColor`, which `SHAPE` also uses for its border) — those
-     fields are silently ignored for the group's actual type, so this just flags a likely config mistake rather
-     than rejecting it.
+     `fillColor`/`depthTest`; `LINE` warns on an explicit `icon`/`offsetX`/`offsetY`/`fillColor`/`cssClasses`;
+     `SHAPE` warns on an explicit `icon`/`offsetX`/`offsetY`/`cssClasses` (but *not* `lineWidth`/`lineColor`, which
+     `SHAPE` also uses for its border) — those fields are silently ignored for the group's actual type, so this
+     just flags a likely config mistake rather than rejecting it. `sorting`/`toggleable` apply to every group type
+     (thin `MarkerSet` passthroughs — see `core-pipeline.md` §6) so neither has a type-mismatch warning.
   4. Any exception during load (`Gson.fromJson` failure, I/O error, or a `validateMarkerGroups` failure) logs and
      returns `null`, and `ConfigManager.loadCoreConfig` falls back to `new BMSMConfigV2()` defaults — a broken
      config file never prevents server startup, it just silently reverts to a single default `[poi]` group.
@@ -221,5 +229,5 @@ in place. Old region files (or a not-yet-migrated legacy `signs.json`) on live s
 the version they were written with.
 
 ---
-*Last updated: 2026-08-22 | Verified against: docs/tpwalke2/refactor (f1d4730)*
+*Last updated: 2026-09-02 | Verified against: feature/tpwalke2/197-marker-polish (1745bc2)*
 

--- a/agent-context/context/core-pipeline.md
+++ b/agent-context/context/core-pipeline.md
@@ -359,7 +359,9 @@ Two id schemes now exist side by side, unified behind one interface:
   now-corrected assignment point.
 - `getMarkerSets(identifier)` is `synchronized`; on cache miss it resolves `BlueMapAPI.getWorld(mapId)` →
   `.getMaps()`, and for each map either fetches an existing `MarkerSet` by `markerGroup.name()` or builds+registers
-  one (`label`, `defaultHidden` from the `MarkerGroup`). One `MarkerSetIdentifier` can map to *multiple*
+  one (`label`, `defaultHidden`, `sorting`, `toggleable` from the `MarkerGroup` — `sorting`/`toggleable` are thin
+  BlueMap `MarkerSet` passthroughs, unlike `depthTest`/`cssClasses` below which are per-marker). One
+  `MarkerSetIdentifier` can map to *multiple*
   `MarkerSet`s if a world has multiple BlueMap maps rendered for it — every dispatched action applies to all of them.
   The `markerSetsCache.putIfAbsent(...)`/debug-log call now happens **once, after** the per-map `forEach` loop
   (ticket 06) rather than repeated inside it against the same `markerSetsToReturn` list reference — the old
@@ -395,23 +397,28 @@ Two id schemes now exist side by side, unified behind one interface:
   (defensively — `SignManager` should never dispatch below 2 points) if `action.getPoints().size() < 2`, otherwise
   builds a `de.bluecolored.bluemap.api.math.Line` from the action's `LinePoint`s (via `Vector3d`), parses
   `action.getLineColor()` through `ColorUtils.parseHex` (`common`, plain Java) into `de.bluecolored.bluemap.api.math.Color`,
-  and `put`s a `LineMarker.builder().label(...).detail(HtmlUtils.toHtmlDetail(...)).line(line).lineWidth(...).lineColor(...).build()`
-  into each marker set's map, keyed by `action.getMarkerIdentifier().getId()` (the content-keyed `"line:" + label`
-  id, §5). `ColorUtils.parseHex` is the only conversion point from the persisted hex string to a real color object,
-  mirroring how `HtmlUtils` is the only conversion point for HTML-escaped `detail` — both convert at the BlueMap-API
-  call site, keeping the rest of the pipeline in plain-Java, unescaped/unconverted form.
+  and `put`s a `LineMarker.builder().label(...).detail(HtmlUtils.toHtmlDetail(...)).line(line).lineWidth(...).lineColor(...)
+  .depthTestEnabled(markerGroup.depthTest()).build()` into each marker set's map, keyed by
+  `action.getMarkerIdentifier().getId()` (the content-keyed `"line:" + label` id, §5). `ColorUtils.parseHex` is the
+  only conversion point from the persisted hex string to a real color object, mirroring how `HtmlUtils` is the only
+  conversion point for HTML-escaped `detail` — both convert at the BlueMap-API call site, keeping the rest of the
+  pipeline in plain-Java, unescaped/unconverted form.
 - `setShapeMarker(SetShapeMarkerAction, Stream<Map<String, Marker>>)` is the `SHAPE` counterpart: bails
   (defensively, mirroring `setLineMarker`) if `action.getPoints().size() < 3`, builds a 2D `Shape` footprint from
   the points' `x`/`z` only, and takes the marker's rendered height from the **tallest member**:
   `points.stream().mapToInt(LinePoint::y).max()`. Parses both `lineColor` and `fillColor` through `ColorUtils.parseHex`
   (fill defaults to a translucent red, `#FF000033`, unlike `lineColor`'s opaque default — see
   `config-and-persistence.md`), then `put`s a `ShapeMarker.builder().label(...).detail(...).shape(shape,
-  height).lineWidth(...).lineColor(...).fillColor(...).build()` into each marker set's map, keyed by
-  `action.getMarkerIdentifier().getId()` (the content-keyed `"shape:" + label` id, §5).
+  height).lineWidth(...).lineColor(...).fillColor(...).depthTestEnabled(markerGroup.depthTest()).build()` into each
+  marker set's map, keyed by `action.getMarkerIdentifier().getId()` (the content-keyed `"shape:" + label` id, §5).
 - `addMarker` only actually builds a marker `if (markerGroup.type() == MarkerGroupType.POI)` — this is a real,
   live branch now that `MarkerGroupType.LINE`/`SHAPE` exist (no longer future-proofing for values that didn't
   exist): a `LINE`- or `SHAPE`-typed group's signs never reach `addMarker` at all, since `SignManager`'s transition
-  table (§3) routes those representations to their own `Set`/`Remove` actions instead of `AddMarkerAction`.
+  table (§3) routes those representations to their own `Set`/`Remove` actions instead of `AddMarkerAction`. It also
+  conditionally calls `markerBuilder.styleClasses(markerGroup.cssClasses().toArray(new String[0]))` when
+  `cssClasses` is non-empty — the only marker-builder call gated on the field being present rather than always
+  called with a possibly-default value, since BlueMap's `styleClasses` has no meaningful "unset" default to fall
+  back to.
 - **HTML escaping (fixed)**: `addMarker`/`updateMarker` wrap `detail` with `HtmlUtils.toHtmlDetail(...)` (`common`
   package) before it reaches `POIMarker.builder().detail(...)` / `poiMarker.setDetail(...)` — BlueMap renders
   `detail` as raw HTML (unlike `label`, which BlueMap's own `Marker.setLabel()` escapes), and sign text is
@@ -530,5 +537,5 @@ gating" section. This section covers the code-level mechanics.
   themselves are otherwise unchanged — the fix is localized to `prepareGated`.
 
 ---
-*Last updated: 2026-08-22 | Verified against: docs/tpwalke2/refactor (f1d4730)*
+*Last updated: 2026-09-02 | Verified against: feature/tpwalke2/197-marker-polish (1745bc2)*
 

--- a/agent-context/context/testing.md
+++ b/agent-context/context/testing.md
@@ -157,7 +157,12 @@ As of `feature/tpwalke2/67-map-bounds` (`217c17f`), `src/test/java/com/tpwalke2/
   as-is — see `resolveLineWidth`/`resolveLineColor` in `config-and-persistence.md`. `fillColor` has the same shape
   of coverage for `SHAPE` groups: default fallback (`#FF000033`) when unset, a valid custom hex preserved, an
   invalid hex falling back to the default with a warning, and warning-only (not load-failing) tests for
-  `fillColor` set on a `POI` or `LINE` group.
+  `fillColor` set on a `POI` or `LINE` group. `sorting`/`toggleable`/`depthTest`/`cssClasses` (ticket 197) each have
+  omitted-defaults and explicit-value-preserved tests; `sorting` additionally has malformed-value fallback tests
+  (a non-numeric string, a JSON array, a number outside `int` range — all fall back to `0` with a warning, per
+  `resolveSorting` in `config-and-persistence.md`); `cssClasses` has a null-entry-dropped test and warning-only
+  tests for `cssClasses` set on a `LINE`/`SHAPE` group; `depthTest` has a warning-only test for `depthTest` set on
+  a `POI` group.
 - `config/ConfigManagerTest.java` — `get()` returns the config from the most recent `reload`; falls back to
   `new BMSMConfigV2()` defaults when the configured path fails to load; a second `reload()` replaces (not merges
   with) what an earlier `reload` cached.
@@ -258,5 +263,5 @@ JUnit reporter action** — those actions don't get `checks: write` permission o
 public repo, so the summary step was written to need no extra permissions.
 
 ---
-*Last updated: 2026-08-22 | Verified against: docs/tpwalke2/refactor (f1d4730)*
+*Last updated: 2026-09-02 | Verified against: feature/tpwalke2/197-marker-polish (1745bc2)*
 

--- a/agent-context/plans/marker-polish/issues/01-marker-group-config-fields.md
+++ b/agent-context/plans/marker-polish/issues/01-marker-group-config-fields.md
@@ -23,4 +23,5 @@ See `../spec.md` for full context (Implementation/Testing Decisions sections).
 
 **Implementation note:** `LoadingMarkerGroupV2.sorting` is typed as a raw `JsonElement` (not `Integer`), so a
 non-integer `sorting` value falls back with a warning instead of failing Gson's parse for the whole config;
-`ConfigProvider.resolveSorting` validates it manually via `getAsInt()`.
+`ConfigProvider.resolveSorting` validates it manually via `getAsBigDecimal().intValueExact()`, requiring a numeric
+`JsonPrimitive` (a numeric string is rejected, not coerced).

--- a/agent-context/plans/marker-polish/issues/01-marker-group-config-fields.md
+++ b/agent-context/plans/marker-polish/issues/01-marker-group-config-fields.md
@@ -8,15 +8,19 @@ See `../spec.md` for full context (Implementation/Testing Decisions sections).
 
 **Blocked by:** None — can start immediately.
 
-**Status:** ready-for-agent
+**Status:** resolved
 
-- [ ] `MarkerGroup` record gains `sorting` (int, default `0`, all types), `toggleable` (boolean, default `true`, all
+- [x] `MarkerGroup` record gains `sorting` (int, default `0`, all types), `toggleable` (boolean, default `true`, all
       types), `depthTest` (boolean, default `true`, `LINE`/`SHAPE` only), `cssClasses` (`List<String>`, default
       empty, `POI` only). All existing call sites (main + test) updated for the new constructor arity.
-- [ ] `ConfigProvider` gains `resolveSorting`/`resolveToggleable`/`resolveDepthTest`/`resolveCssClasses`: default
+- [x] `ConfigProvider` gains `resolveSorting`/`resolveToggleable`/`resolveDepthTest`/`resolveCssClasses`: default
       when unset, malformed `sorting` value falls back to `0` and logs a warning.
-- [ ] Field-mismatch warnings extend to `depthTest` set on a `POI` group and `cssClasses` set on a `LINE`/`SHAPE`
+- [x] Field-mismatch warnings extend to `depthTest` set on a `POI` group and `cssClasses` set on a `LINE`/`SHAPE`
       group (warn-and-ignore, same as existing `icon`-on-`LINE`/`fillColor`-on-`POI` warnings).
-- [ ] `ConfigProviderTest` covers default/valid/malformed resolution for all four fields and both new mismatch
+- [x] `ConfigProviderTest` covers default/valid/malformed resolution for all four fields and both new mismatch
       warnings.
-- [ ] `./gradlew build` passes (compiles + all unit tests).
+- [x] `./gradlew build` passes (compiles + all unit tests).
+
+**Implementation note:** `LoadingMarkerGroupV2.sorting` is typed as a raw `JsonElement` (not `Integer`), so a
+non-integer `sorting` value falls back with a warning instead of failing Gson's parse for the whole config;
+`ConfigProvider.resolveSorting` validates it manually via `getAsInt()`.

--- a/agent-context/plans/marker-polish/issues/02-bluemapapiconnector-wiring.md
+++ b/agent-context/plans/marker-polish/issues/02-bluemapapiconnector-wiring.md
@@ -7,15 +7,15 @@ See `../spec.md` for full context.
 
 **Blocked by:** 01-marker-group-config-fields.md
 
-**Status:** ready-for-agent
+**Status:** code complete; manual verification outstanding
 
-- [ ] `getOrCreateMarkerSet`'s `MarkerSet.builder()` call adds `.sorting(markerGroup.sorting())` and
+- [x] `getOrCreateMarkerSet`'s `MarkerSet.builder()` call adds `.sorting(markerGroup.sorting())` and
       `.toggleable(markerGroup.toggleable())` alongside the existing `.defaultHidden(...)`.
-- [ ] `setLineMarker`/`setShapeMarker`'s `LineMarker.builder()`/`ShapeMarker.builder()` calls add
+- [x] `setLineMarker`/`setShapeMarker`'s `LineMarker.builder()`/`ShapeMarker.builder()` calls add
       `.depthTestEnabled(markerGroup.depthTest())`.
-- [ ] The POI marker creation path's `POIMarker.builder()` call adds
+- [x] The POI marker creation path's `POIMarker.builder()` call adds
       `.styleClasses(markerGroup.cssClasses().toArray(new String[0]))` when `cssClasses` is non-empty.
-- [ ] `./gradlew build` passes.
+- [x] `./gradlew build` passes.
 - [ ] Manually verified via `runServer`: set each field on a test group, `/bluemap reload`, confirm menu order,
       toggle-ability, depth-test behavior (place a `LINE`/`SHAPE` group underground), and a `custom.css` rule
       targeting a configured `cssClasses` value all take effect in BlueMap's web UI.

--- a/agent-context/plans/marker-polish/issues/03-readme-docs.md
+++ b/agent-context/plans/marker-polish/issues/03-readme-docs.md
@@ -7,9 +7,9 @@ See `../spec.md` for full context.
 
 **Blocked by:** 01-marker-group-config-fields.md, 02-bluemapapiconnector-wiring.md
 
-**Status:** ready-for-agent
+**Status:** resolved
 
-- [ ] `../../../../README.md` documents `sorting`, `toggleable`, `depthTest`, `cssClasses` — scope (which group types), default
+- [x] `../../../../README.md` documents `sorting`, `toggleable`, `depthTest`, `cssClasses` — scope (which group types), default
       value, and a one-line description of the effect, matching the existing entries for `lineWidth`/`fillColor`.
-- [ ] `../../../../AGENTS.md`'s Marker groups and config section mentions the new fields if warranted (short addition, not a
+- [x] `../../../../AGENTS.md`'s Marker groups and config section mentions the new fields if warranted (short addition, not a
       rewrite).

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ loader_version=0.19.3
 # Mod Properties
 mod_id=bluemapsignmarkers
 mod_name=BlueMap Sign Markers
-mod_version=26.2-0.21.0
+mod_version=26.2-0.22.0
 mod_description=A plugin for BlueMap that creates markers from signs
 maven_group=com.tpwalke2.bluemapsignmarkers
 archives_base_name=bluemapsignmarkers

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProvider.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProvider.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -179,6 +180,9 @@ public class ConfigProvider {
                 if (markerGroup.fillColor() != null) {
                     LOGGER.warn("Marker group '{}' is type POI but has 'fillColor' set; this field is ignored for POI groups", name);
                 }
+                if (markerGroup.depthTest() != null) {
+                    LOGGER.warn("Marker group '{}' is type POI but has 'depthTest' set; this field is ignored for POI groups", name);
+                }
             } else if (type == MarkerGroupType.LINE) {
                 if (markerGroup.icon() != null) {
                     LOGGER.warn("Marker group '{}' is type LINE but has 'icon' set; this field is ignored for LINE groups", name);
@@ -192,6 +196,9 @@ public class ConfigProvider {
                 if (markerGroup.fillColor() != null) {
                     LOGGER.warn("Marker group '{}' is type LINE but has 'fillColor' set; this field is ignored for LINE groups", name);
                 }
+                if (markerGroup.cssClasses() != null && !markerGroup.cssClasses().isEmpty()) {
+                    LOGGER.warn("Marker group '{}' is type LINE but has 'cssClasses' set; this field is ignored for LINE groups", name);
+                }
             } else if (type == MarkerGroupType.SHAPE) {
                 if (markerGroup.icon() != null) {
                     LOGGER.warn("Marker group '{}' is type SHAPE but has 'icon' set; this field is ignored for SHAPE groups", name);
@@ -201,6 +208,9 @@ public class ConfigProvider {
                 }
                 if (markerGroup.offsetY() != null) {
                     LOGGER.warn("Marker group '{}' is type SHAPE but has 'offsetY' set; this field is ignored for SHAPE groups", name);
+                }
+                if (markerGroup.cssClasses() != null && !markerGroup.cssClasses().isEmpty()) {
+                    LOGGER.warn("Marker group '{}' is type SHAPE but has 'cssClasses' set; this field is ignored for SHAPE groups", name);
                 }
             }
         }
@@ -222,8 +232,48 @@ public class ConfigProvider {
                 markerGroup.maxDistance() == null ? 10000000.0 : markerGroup.maxDistance(),
                 resolveLineWidth(markerGroup),
                 resolveLineColor(markerGroup),
-                resolveFillColor(markerGroup)
+                resolveFillColor(markerGroup),
+                resolveSorting(markerGroup),
+                resolveToggleable(markerGroup),
+                resolveDepthTest(markerGroup),
+                resolveCssClasses(markerGroup)
         );
+    }
+
+    private static final int DEFAULT_SORTING = 0;
+
+    // sorting is read as a raw JsonElement (see LoadingMarkerGroupV2) specifically so a non-integer value
+    // (e.g. a string) falls back here with a warning instead of failing Gson's parse for the entire config.
+    private static int resolveSorting(LoadingMarkerGroupV2 markerGroup) {
+        var sorting = markerGroup.sorting();
+        if (sorting == null || sorting.isJsonNull()) return DEFAULT_SORTING;
+
+        try {
+            return sorting.getAsInt();
+        } catch (NumberFormatException | UnsupportedOperationException e) {
+            LOGGER.warn("Marker group '{}' has a malformed 'sorting' ({}); falling back to default {}",
+                    markerGroup.name(), sorting, DEFAULT_SORTING);
+            return DEFAULT_SORTING;
+        }
+    }
+
+    private static boolean resolveToggleable(LoadingMarkerGroupV2 markerGroup) {
+        var toggleable = markerGroup.toggleable();
+        return toggleable == null || toggleable;
+    }
+
+    // depthTest is LINE/SHAPE-only (POI markers are always billboarded on top); unset or set on a POI group
+    // both resolve to the BlueMap default of true - warnOnTypeFieldMismatches already warns on the POI case.
+    private static boolean resolveDepthTest(LoadingMarkerGroupV2 markerGroup) {
+        var depthTest = markerGroup.depthTest();
+        return depthTest == null || depthTest;
+    }
+
+    // cssClasses is POI-only; unset or set on a LINE/SHAPE group both resolve to an empty list -
+    // warnOnTypeFieldMismatches already warns on the LINE/SHAPE case.
+    private static List<String> resolveCssClasses(LoadingMarkerGroupV2 markerGroup) {
+        var cssClasses = markerGroup.cssClasses();
+        return cssClasses == null ? List.of() : List.copyOf(cssClasses);
     }
 
     // Falls back to the default width on a non-positive value rather than throwing - a bad config value
@@ -311,6 +361,10 @@ public class ConfigProvider {
                         10000000.0,
                         2,
                         "#FF0000FF",
-                        "#FF000033"));
+                        "#FF000033",
+                        0,
+                        true,
+                        true,
+                        List.of()));
     }
 }

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProvider.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProvider.java
@@ -27,6 +27,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -249,8 +250,8 @@ public class ConfigProvider {
         if (sorting == null || sorting.isJsonNull()) return DEFAULT_SORTING;
 
         try {
-            return sorting.getAsInt();
-        } catch (NumberFormatException | UnsupportedOperationException e) {
+            return sorting.getAsBigDecimal().intValueExact();
+        } catch (RuntimeException e) {
             LOGGER.warn("Marker group '{}' has a malformed 'sorting' ({}); falling back to default {}",
                     markerGroup.name(), sorting, DEFAULT_SORTING);
             return DEFAULT_SORTING;
@@ -273,7 +274,13 @@ public class ConfigProvider {
     // warnOnTypeFieldMismatches already warns on the LINE/SHAPE case.
     private static List<String> resolveCssClasses(LoadingMarkerGroupV2 markerGroup) {
         var cssClasses = markerGroup.cssClasses();
-        return cssClasses == null ? List.of() : List.copyOf(cssClasses);
+        if (cssClasses == null) return List.of();
+
+        var filtered = cssClasses.stream().filter(Objects::nonNull).toList();
+        if (filtered.size() != cssClasses.size()) {
+            LOGGER.warn("Marker group '{}' has null entries in 'cssClasses'; dropping them", markerGroup.name());
+        }
+        return filtered;
     }
 
     // Falls back to the default width on a non-positive value rather than throwing - a bad config value

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProvider.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProvider.java
@@ -250,6 +250,9 @@ public class ConfigProvider {
         if (sorting == null || sorting.isJsonNull()) return DEFAULT_SORTING;
 
         try {
+            if (!sorting.isJsonPrimitive() || !sorting.getAsJsonPrimitive().isNumber()) {
+                throw new IllegalArgumentException("not a numeric JSON primitive");
+            }
             return sorting.getAsBigDecimal().intValueExact();
         } catch (RuntimeException e) {
             LOGGER.warn("Marker group '{}' has a malformed 'sorting' ({}); falling back to default {}",

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProvider.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProvider.java
@@ -267,7 +267,12 @@ public class ConfigProvider {
     // both resolve to the BlueMap default of true - warnOnTypeFieldMismatches already warns on the POI case.
     private static boolean resolveDepthTest(LoadingMarkerGroupV2 markerGroup) {
         var depthTest = markerGroup.depthTest();
-        return depthTest == null || depthTest;
+        if (depthTest == null) return true;
+
+        var type = effectiveType(markerGroup);
+        if (type != MarkerGroupType.LINE && type != MarkerGroupType.SHAPE) return true;
+
+        return depthTest;
     }
 
     // cssClasses is POI-only; unset or set on a LINE/SHAPE group both resolve to an empty list -
@@ -275,6 +280,8 @@ public class ConfigProvider {
     private static List<String> resolveCssClasses(LoadingMarkerGroupV2 markerGroup) {
         var cssClasses = markerGroup.cssClasses();
         if (cssClasses == null) return List.of();
+
+        if (effectiveType(markerGroup) != MarkerGroupType.POI) return List.of();
 
         var filtered = cssClasses.stream().filter(Objects::nonNull).toList();
         if (filtered.size() != cssClasses.size()) {

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/config/persistence/LoadingBMSMConfigV2.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/config/persistence/LoadingBMSMConfigV2.java
@@ -1,5 +1,6 @@
 package com.tpwalke2.bluemapsignmarkers.config.persistence;
 
+import com.google.gson.JsonPrimitive;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroup;
 
 public final class LoadingBMSMConfigV2 {
@@ -31,7 +32,11 @@ public final class LoadingBMSMConfigV2 {
                 defaultGroup.maxDistance(),
                 defaultGroup.lineWidth(),
                 defaultGroup.lineColor(),
-                defaultGroup.fillColor());
+                defaultGroup.fillColor(),
+                new JsonPrimitive(defaultGroup.sorting()),
+                defaultGroup.toggleable(),
+                defaultGroup.depthTest(),
+                defaultGroup.cssClasses());
     }
 
     public LoadingMarkerGroupV2[] getMarkerGroups() {

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/config/persistence/LoadingMarkerGroupV2.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/config/persistence/LoadingMarkerGroupV2.java
@@ -1,7 +1,10 @@
 package com.tpwalke2.bluemapsignmarkers.config.persistence;
 
+import com.google.gson.JsonElement;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupMatchType;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupType;
+
+import java.util.List;
 
 public record LoadingMarkerGroupV2(
         String prefix,
@@ -16,5 +19,12 @@ public record LoadingMarkerGroupV2(
         Double maxDistance,
         Integer lineWidth,
         String lineColor,
-        String fillColor) {
+        String fillColor,
+        // JsonElement (rather than Integer) so a non-integer JSON value doesn't fail the whole config's Gson
+        // parse - resolveSorting in ConfigProvider validates it manually and falls back to the default on a
+        // malformed value, the same "never crash on a bad field" treatment lineWidth/lineColor get downstream.
+        JsonElement sorting,
+        Boolean toggleable,
+        Boolean depthTest,
+        List<String> cssClasses) {
 }

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
@@ -472,6 +472,10 @@ public class BlueMapAPIConnector {
                         .toggleable(markerSetIdentifier.markerGroup().toggleable())
                         .build();
                 blueMapMap.getMarkerSets().putIfAbsent(markerSetIdentifier.markerGroup().name(), markerSet);
+            } else {
+                markerSet.setDefaultHidden(markerSetIdentifier.markerGroup().defaultHidden());
+                markerSet.setSorting(markerSetIdentifier.markerGroup().sorting());
+                markerSet.setToggleable(markerSetIdentifier.markerGroup().toggleable());
             }
             markerSetsToReturn.add(new MappedMarkerSet(blueMapMap.getId(), markerSet));
         });

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
@@ -362,6 +362,7 @@ public class BlueMapAPIConnector {
                 .line(line)
                 .lineWidth(action.getLineWidth())
                 .lineColor(toBlueMapColor(color))
+                .depthTestEnabled(markerGroup.depthTest())
                 .build();
         marker.setMinDistance(markerGroup.minDistance());
         marker.setMaxDistance(markerGroup.maxDistance());
@@ -388,6 +389,7 @@ public class BlueMapAPIConnector {
                 .lineWidth(action.getLineWidth())
                 .lineColor(toBlueMapColor(lineColor))
                 .fillColor(toBlueMapColor(fillColor))
+                .depthTestEnabled(markerGroup.depthTest())
                 .build();
         marker.setMinDistance(markerGroup.minDistance());
         marker.setMaxDistance(markerGroup.maxDistance());
@@ -407,6 +409,10 @@ public class BlueMapAPIConnector {
 
             if (markerGroup.icon() != null && !markerGroup.icon().isEmpty()) {
                 markerBuilder.icon(markerGroup.icon(), markerGroup.offsetX(), markerGroup.offsetY());
+            }
+
+            if (!markerGroup.cssClasses().isEmpty()) {
+                markerBuilder.styleClasses(markerGroup.cssClasses().toArray(new String[0]));
             }
 
             LOGGER.debug("Adding marker (id {}) to marker set", identifier.getId());
@@ -462,6 +468,8 @@ public class BlueMapAPIConnector {
                         .builder()
                         .label(markerSetIdentifier.markerGroup().name())
                         .defaultHidden(markerSetIdentifier.markerGroup().defaultHidden())
+                        .sorting(markerSetIdentifier.markerGroup().sorting())
+                        .toggleable(markerSetIdentifier.markerGroup().toggleable())
                         .build();
                 blueMapMap.getMarkerSets().putIfAbsent(markerSetIdentifier.markerGroup().name(), markerSet);
             }

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/markers/MarkerGroup.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/markers/MarkerGroup.java
@@ -1,5 +1,7 @@
 package com.tpwalke2.bluemapsignmarkers.core.markers;
 
+import java.util.List;
+
 public record MarkerGroup(
         String prefix,
         MarkerGroupMatchType matchType,
@@ -13,7 +15,11 @@ public record MarkerGroup(
         double maxDistance,
         int lineWidth,
         String lineColor,
-        String fillColor) {
+        String fillColor,
+        int sorting,
+        boolean toggleable,
+        boolean depthTest,
+        List<String> cssClasses) {
     public static final MarkerGroup DEFAULT_POI_GROUP = new MarkerGroup(
             "[poi]",
             MarkerGroupMatchType.STARTS_WITH,
@@ -27,9 +33,13 @@ public record MarkerGroup(
             10000000.0,
             2,
             "#FF0000FF",
-            "#FF000033");
+            "#FF000033",
+            0,
+            true,
+            true,
+            List.of());
 
     public MarkerGroup withType(MarkerGroupType type) {
-        return new MarkerGroup(prefix, matchType, type, name, icon, offsetX, offsetY, defaultHidden, minDistance, maxDistance, lineWidth, lineColor, fillColor);
+        return new MarkerGroup(prefix, matchType, type, name, icon, offsetX, offsetY, defaultHidden, minDistance, maxDistance, lineWidth, lineColor, fillColor, sorting, toggleable, depthTest, cssClasses);
     }
 }

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProviderTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProviderTest.java
@@ -581,12 +581,72 @@ class ConfigProviderTest {
     }
 
     @Test
+    void loadConfigDropsNullEntriesInCssClasses(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[poi]", "name": "POI Group", "cssClasses": ["custom-poi", null] }
+                  ]
+                }
+                """);
+
+        var result = new BMSMConfigV2[1];
+        var warnings = captureWarnMessages(() -> ConfigProvider.loadConfig(path), result);
+        var config = result[0];
+
+        assertEquals(1, config.getMarkerGroups().length);
+        assertEquals(List.of("custom-poi"), config.getMarkerGroups()[0].cssClasses());
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("cssClasses")));
+    }
+
+    @Test
     void loadConfigFallsBackToDefaultSortingWhenMalformed(@TempDir Path tempDir) throws IOException {
         var path = tempDir.resolve("BMSM-Core.json");
         Files.writeString(path, """
                 {
                   "markerGroups": [
                     { "prefix": "[poi]", "name": "POI Group", "sorting": "notanumber" }
+                  ]
+                }
+                """);
+
+        var result = new BMSMConfigV2[1];
+        var warnings = captureWarnMessages(() -> ConfigProvider.loadConfig(path), result);
+        var config = result[0];
+
+        assertEquals(1, config.getMarkerGroups().length);
+        assertEquals(0, config.getMarkerGroups()[0].sorting());
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("sorting")));
+    }
+
+    @Test
+    void loadConfigFallsBackToDefaultSortingWhenAnArray(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[poi]", "name": "POI Group", "sorting": [1, 2] }
+                  ]
+                }
+                """);
+
+        var result = new BMSMConfigV2[1];
+        var warnings = captureWarnMessages(() -> ConfigProvider.loadConfig(path), result);
+        var config = result[0];
+
+        assertEquals(1, config.getMarkerGroups().length);
+        assertEquals(0, config.getMarkerGroups()[0].sorting());
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("sorting")));
+    }
+
+    @Test
+    void loadConfigFallsBackToDefaultSortingWhenOutOfIntRange(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[poi]", "name": "POI Group", "sorting": 99999999999999999999999999 }
                   ]
                 }
                 """);

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProviderTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProviderTest.java
@@ -509,11 +509,151 @@ class ConfigProviderTest {
                         10000000.0,
                         2,
                         "#FF0000FF",
-                        "#FF000033"));
+                        "#FF000033",
+                        0,
+                        true,
+                        true,
+                        List.of()));
 
         ConfigProvider.saveConfig(original, path);
         var reloaded = ConfigProvider.loadConfig(path);
 
         assertEquals("地図マーカー éèà", reloaded.getMarkerGroups()[0].name());
+    }
+
+    @Test
+    void loadConfigDefaultsSortingToggleableDepthTestAndCssClassesWhenOmitted(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[poi]", "name": "POI Group" }
+                  ]
+                }
+                """);
+
+        var config = ConfigProvider.loadConfig(path);
+
+        assertEquals(1, config.getMarkerGroups().length);
+        var group = config.getMarkerGroups()[0];
+        assertEquals(0, group.sorting());
+        assertTrue(group.toggleable());
+        assertTrue(group.depthTest());
+        assertTrue(group.cssClasses().isEmpty());
+    }
+
+    @Test
+    void loadConfigPreservesExplicitSortingToggleableDepthTestAndCssClasses(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[line]", "name": "Line Group", "type": "LINE", "sorting": 5, "toggleable": false, "depthTest": false }
+                  ]
+                }
+                """);
+
+        var config = ConfigProvider.loadConfig(path);
+
+        assertEquals(1, config.getMarkerGroups().length);
+        var group = config.getMarkerGroups()[0];
+        assertEquals(5, group.sorting());
+        assertFalse(group.toggleable());
+        assertFalse(group.depthTest());
+    }
+
+    @Test
+    void loadConfigPreservesExplicitCssClassesOnAPOIGroup(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[poi]", "name": "POI Group", "cssClasses": ["custom-poi", "highlight"] }
+                  ]
+                }
+                """);
+
+        var config = ConfigProvider.loadConfig(path);
+
+        assertEquals(1, config.getMarkerGroups().length);
+        var group = config.getMarkerGroups()[0];
+        assertEquals(List.of("custom-poi", "highlight"), group.cssClasses());
+    }
+
+    @Test
+    void loadConfigFallsBackToDefaultSortingWhenMalformed(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[poi]", "name": "POI Group", "sorting": "notanumber" }
+                  ]
+                }
+                """);
+
+        var result = new BMSMConfigV2[1];
+        var warnings = captureWarnMessages(() -> ConfigProvider.loadConfig(path), result);
+        var config = result[0];
+
+        assertEquals(1, config.getMarkerGroups().length);
+        assertEquals(0, config.getMarkerGroups()[0].sorting());
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("sorting")));
+    }
+
+    @Test
+    void loadConfigWarnsWhenDepthTestIsSetOnAPOIGroup(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[poi]", "name": "POI Group", "type": "POI", "depthTest": false }
+                  ]
+                }
+                """);
+
+        var result = new BMSMConfigV2[1];
+        var warnings = captureWarnMessages(() -> ConfigProvider.loadConfig(path), result);
+        var config = result[0];
+
+        assertEquals(1, config.getMarkerGroups().length);
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("depthTest")));
+    }
+
+    @Test
+    void loadConfigWarnsWhenCssClassesIsSetOnALineGroup(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[line]", "name": "Line Group", "type": "LINE", "cssClasses": ["ignored"] }
+                  ]
+                }
+                """);
+
+        var result = new BMSMConfigV2[1];
+        var warnings = captureWarnMessages(() -> ConfigProvider.loadConfig(path), result);
+        var config = result[0];
+
+        assertEquals(1, config.getMarkerGroups().length);
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("cssClasses")));
+    }
+
+    @Test
+    void loadConfigWarnsWhenCssClassesIsSetOnAShapeGroup(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[shape]", "name": "Shape Group", "type": "SHAPE", "cssClasses": ["ignored"] }
+                  ]
+                }
+                """);
+
+        var result = new BMSMConfigV2[1];
+        var warnings = captureWarnMessages(() -> ConfigProvider.loadConfig(path), result);
+        var config = result[0];
+
+        assertEquals(1, config.getMarkerGroups().length);
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("cssClasses")));
     }
 }

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProviderTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProviderTest.java
@@ -621,6 +621,26 @@ class ConfigProviderTest {
     }
 
     @Test
+    void loadConfigFallsBackToDefaultSortingWhenANumericString(@TempDir Path tempDir) throws IOException {
+        var path = tempDir.resolve("BMSM-Core.json");
+        Files.writeString(path, """
+                {
+                  "markerGroups": [
+                    { "prefix": "[poi]", "name": "POI Group", "sorting": "5" }
+                  ]
+                }
+                """);
+
+        var result = new BMSMConfigV2[1];
+        var warnings = captureWarnMessages(() -> ConfigProvider.loadConfig(path), result);
+        var config = result[0];
+
+        assertEquals(1, config.getMarkerGroups().length);
+        assertEquals(0, config.getMarkerGroups()[0].sorting());
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("sorting")));
+    }
+
+    @Test
     void loadConfigFallsBackToDefaultSortingWhenAnArray(@TempDir Path tempDir) throws IOException {
         var path = tempDir.resolve("BMSM-Core.json");
         Files.writeString(path, """

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProviderTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/config/ConfigProviderTest.java
@@ -676,6 +676,7 @@ class ConfigProviderTest {
         var config = result[0];
 
         assertEquals(1, config.getMarkerGroups().length);
+        assertTrue(config.getMarkerGroups()[0].depthTest());
         assertTrue(warnings.stream().anyMatch(m -> m.contains("depthTest")));
     }
 
@@ -695,6 +696,7 @@ class ConfigProviderTest {
         var config = result[0];
 
         assertEquals(1, config.getMarkerGroups().length);
+        assertTrue(config.getMarkerGroups()[0].cssClasses().isEmpty());
         assertTrue(warnings.stream().anyMatch(m -> m.contains("cssClasses")));
     }
 
@@ -714,6 +716,7 @@ class ConfigProviderTest {
         var config = result[0];
 
         assertEquals(1, config.getMarkerGroups().length);
+        assertTrue(config.getMarkerGroups()[0].cssClasses().isEmpty());
         assertTrue(warnings.stream().anyMatch(m -> m.contains("cssClasses")));
     }
 }

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/actions/ActionFactoryTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/actions/ActionFactoryTest.java
@@ -208,18 +208,18 @@ class ActionFactoryTest {
     private static MarkerGroup markerGroup(String prefix) {
         return new MarkerGroup(
                 prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, prefix, "icon.png", 0, 0, false, 0, 0,
-                2, "#FF0000FF", "#FF000033");
+                2, "#FF0000FF", "#FF000033", 0, true, true, List.of());
     }
 
     private static MarkerGroup lineMarkerGroup(String prefix) {
         return new MarkerGroup(
                 prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.LINE, prefix, "icon.png", 0, 0, false, 0, 0,
-                2, "#FF0000FF", "#FF000033");
+                2, "#FF0000FF", "#FF000033", 0, true, true, List.of());
     }
 
     private static MarkerGroup shapeMarkerGroup(String prefix) {
         return new MarkerGroup(
                 prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.SHAPE, prefix, null, 0, 0, false, 0, 0,
-                2, "#FF0000FF", "#FF000033");
+                2, "#FF0000FF", "#FF000033", 0, true, true, List.of());
     }
 }

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/markers/MarkerSetIdentifierCollectionTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/markers/MarkerSetIdentifierCollectionTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -115,6 +116,6 @@ class MarkerSetIdentifierCollectionTest {
     private static MarkerGroup markerGroup(String prefix) {
         return new MarkerGroup(
                 prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, prefix, "icon.png", 0, 0, false, 0, 0,
-                2, "#FF0000FF", "#FF000033");
+                2, "#FF0000FF", "#FF000033", 0, true, true, List.of());
     }
 }

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/ParsingContextTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/ParsingContextTest.java
@@ -5,6 +5,8 @@ import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupMatchType;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupType;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -64,6 +66,6 @@ class ParsingContextTest {
     private static MarkerGroup markerGroup(String prefix) {
         return new MarkerGroup(
                 prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, prefix, "icon.png", 0, 0, false, 0, 0,
-                2, "#FF0000FF", "#FF000033");
+                2, "#FF0000FF", "#FF000033", 0, true, true, List.of());
     }
 }

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignEntryHelperTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignEntryHelperTest.java
@@ -5,6 +5,7 @@ import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupMatchType;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupType;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,7 +18,7 @@ class SignEntryHelperTest {
     private static final SignEntryKey KEY = new SignEntryKey(1, 2, 3, "minecraft:overworld");
 
     private static MarkerGroup poiGroup(String prefix) {
-        return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, "Points of Interest", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
+        return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, "Points of Interest", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033", 0, true, true, List.of());
     }
 
     private static SignEntry signEntry(SignLinesParseResult frontText, SignLinesParseResult backText) {

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignLinesParserTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignLinesParserTest.java
@@ -13,11 +13,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class SignLinesParserTest {
 
     private static MarkerGroup startsWithGroup(String prefix, String name) {
-        return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, name, null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
+        return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, name, null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033", 0, true, true, List.of());
     }
 
     private static MarkerGroup regexGroup(String pattern, String name) {
-        return new MarkerGroup(pattern, MarkerGroupMatchType.REGEX, MarkerGroupType.POI, name, null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
+        return new MarkerGroup(pattern, MarkerGroupMatchType.REGEX, MarkerGroupType.POI, name, null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033", 0, true, true, List.of());
     }
 
     @Test

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignManagerTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignManagerTest.java
@@ -22,7 +22,7 @@ class SignManagerTest {
 
     private static MarkerGroup regexGroup(String prefix) {
         return new MarkerGroup(prefix, MarkerGroupMatchType.REGEX, MarkerGroupType.POI,
-                "name", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
+                "name", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033", 0, true, true, List.of());
     }
 
     @Test

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolverTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/SignTransitionResolverTest.java
@@ -32,12 +32,12 @@ class SignTransitionResolverTest {
 
     private static MarkerGroup poiGroup(String prefix) {
         return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI,
-                "name", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
+                "name", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033", 0, true, true, List.of());
     }
 
     private static MarkerGroup lineGroup(String prefix) {
         return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.LINE,
-                "name", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
+                "name", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033", 0, true, true, List.of());
     }
 
     private static MarkerGroup shapeGroup(String prefix) {
@@ -46,7 +46,7 @@ class SignTransitionResolverTest {
 
     private static MarkerGroup shapeGroup(String prefix, String name) {
         return new MarkerGroup(prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.SHAPE,
-                name, null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
+                name, null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033", 0, true, true, List.of());
     }
 
     private static SignEntry signEntry(int x, int y, int z, String prefix, String label, String detail, long createdAtMillis) {

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/LegacySignFileMigratorTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/LegacySignFileMigratorTest.java
@@ -65,7 +65,7 @@ class LegacySignFileMigratorTest {
         var storageRoot = tempDir.resolve("storage");
         var poiGroup = new MarkerGroup(
                 "[poi]", MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI,
-                "Points of Interest", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033");
+                "Points of Interest", null, 0, 0, false, 0.0, 10000000.0, 2, "#FF0000FF", "#FF000033", 0, true, true, List.of());
 
         // Already-namespaced dimension string: Version1SignEntryLoader's legacy-shorthand ("overworld"/"nether"/
         // "end") normalization branch reaches into net.minecraft.world.level.Level's static constants, which

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/Version1SignEntryLoaderTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/Version1SignEntryLoaderTest.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -26,7 +27,7 @@ class Version1SignEntryLoaderTest {
     private static final Gson GSON = new Gson();
     private static final MarkerGroup[] POI_GROUP = {
             new MarkerGroup("[poi]", MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI,
-                    "[poi]", null, 0, 0, false, 0, 0, 2, "#FF0000FF", "#FF000033")
+                    "[poi]", null, 0, 0, false, 0, 0, 2, "#FF0000FF", "#FF000033", 0, true, true, List.of())
     };
 
     private static String load(Path tempDir, String legacyDimension) throws IOException {

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/Version3ConverterTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/Version3ConverterTest.java
@@ -9,6 +9,8 @@ import com.tpwalke2.bluemapsignmarkers.core.signs.persistence.models.SignEntryV2
 import com.tpwalke2.bluemapsignmarkers.core.signs.persistence.models.SignLinesParseResultV2;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -19,7 +21,7 @@ class Version3ConverterTest {
     private static MarkerGroup poiGroup(String prefix) {
         return new MarkerGroup(
                 prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, prefix, null, 0, 0, false, 0, 0,
-                2, "#FF0000FF", "#FF000033");
+                2, "#FF0000FF", "#FF000033", 0, true, true, List.of());
     }
 
     private static SignEntryV2 entryWith(SignLinesParseResultV2 front, SignLinesParseResultV2 back) {

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/VersionedFileSignEntryLoaderTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/signs/persistence/loaders/VersionedFileSignEntryLoaderTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,7 +38,7 @@ class VersionedFileSignEntryLoaderTest {
     private static MarkerGroup poiGroup(String prefix) {
         return new MarkerGroup(
                 prefix, MarkerGroupMatchType.STARTS_WITH, MarkerGroupType.POI, prefix, null, 0, 0, false, 0, 0,
-                2, "#FF0000FF", "#FF000033");
+                2, "#FF0000FF", "#FF000033", 0, true, true, List.of());
     }
 
     @Test


### PR DESCRIPTION
## What
Adds four new `MarkerGroup` config fields — `sorting`, `toggleable`, `depthTest`, `cssClasses` — and wires them into BlueMap marker/marker-set creation.

## Why
Rounds out marker styling/behavior controls (menu order, hideability, terrain occlusion, custom CSS hooks) that BlueMap's API already supports but the mod didn't expose.

## Changes
- `MarkerGroup` record gains `sorting` (int, default `0`, all types), `toggleable` (boolean, default `true`, all types), `depthTest` (boolean, default `true`, `LINE`/`SHAPE` only), `cssClasses` (`List<String>`, default empty, `POI` only)
- `LoadingMarkerGroupV2.sorting` is typed as a raw `JsonElement` (not `Integer`) so a non-integer value falls back with a warning instead of failing Gson's parse for the whole config
- `ConfigProvider` adds `resolveSorting`/`resolveToggleable`/`resolveDepthTest`/`resolveCssClasses`, plus type-mismatch warnings for `depthTest` on `POI` and `cssClasses` on `LINE`/`SHAPE` (warn-and-ignore, consistent with existing field-mismatch handling)
- `BlueMapAPIConnector` wires the new fields into BlueMap builder calls: `.sorting()`/`.toggleable()` on `MarkerSet.builder()`, `.depthTestEnabled()` on `LineMarker`/`ShapeMarker` builders, `.styleClasses()` on `POIMarker.builder()` when `cssClasses` is non-empty
- `README.md`/`AGENTS.md` updated to document the new fields
- All test call sites updated for the new `MarkerGroup` constructor arity; new `ConfigProviderTest` cases cover defaults, valid/malformed `sorting`, null-entry filtering in `cssClasses`, and both new mismatch warnings

## Testing
- `./gradlew build` (compiles + unit tests)
- Manual verification via `runServer` still outstanding (per `agent-context/plans/marker-polish/issues/02-bluemapapiconnector-wiring.md`): confirm menu order, toggle-ability, depth-test behavior, and a `custom.css` rule against `cssClasses` all take effect in BlueMap's web UI