### PR TITLE
#209 Shrink BlueMapAPIConnector's marker-mutation surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,12 +90,15 @@ Two Mixins (`src/main/resources/bluemapsignmarkers.mixins.json`) catch the event
    `SignManager` can't be unit tested directly (its constructor builds a `BlueMapAPIConnector`, which touches live
    `BlueMapAPI` static state), but the transition table has no Minecraft/Fabric/BlueMap types in its signature, so
    extracting it makes it directly testable (`SignTransitionResolverTest`).
-3. **`BlueMapAPIConnector`** owns the `ReactiveQueue<MarkerAction>` and all actual BlueMap API calls. Because the
-   BlueMap API is only available while BlueMap itself is enabled, actions are queued and only drained
-   (`markerActionQueue.process()`) while `BlueMapAPI.getInstance().isPresent()`; `BlueMapAPI.onEnable`/`onDisable`
-   start/stop draining and clear/rebuild the marker-set cache. `MarkerSet`s are looked up/created per
-   `MarkerSetIdentifier` (map id + marker group), cached in `markerSetsCache` as `MappedMarkerSet` (pairing the
-   `MarkerSet` with the real `BlueMapMap.getId()` it came from — needed for the per-map render-bounds gating below).
+3. **`BlueMapAPIConnector`** owns the `ReactiveQueue<MarkerAction>`, BlueMap listener lifecycle, action-dispatch
+   orchestration, render-bounds gating, and the `MarkerSet`/render-mask caches. Because the BlueMap API is only
+   available while BlueMap itself is enabled, actions are queued and only drained (`markerActionQueue.process()`)
+   while `BlueMapAPI.getInstance().isPresent()`; `BlueMapAPI.onEnable`/`onDisable` start/stop draining and
+   clear/rebuild the marker-set cache. `MarkerSet`s are looked up/created per `MarkerSetIdentifier` (map id + marker
+   group), cached in `markerSetsCache` as `MappedMarkerSet` (pairing the `MarkerSet` with the real
+   `BlueMapMap.getId()` it came from — needed for the per-map render-bounds gating below). The actual BlueMap marker
+   builder calls (add/update/remove/set, per marker type) live in a separate `MarkerMutations` class (see "Testable
+   vs. game-coupled code" below) that `BlueMapAPIConnector` dispatches into.
 
 `ReactiveQueue<T>` (`core/reactive`) is a small generic building block: an unbounded queue plus a "should I run right
 now" predicate, draining onto a fixed thread pool sized to `availableProcessors()`. It isn't BlueMap-specific — reuse
@@ -130,11 +133,11 @@ lineWidth, lineColor, fillColor, sorting, toggleable, depthTest, cssClasses) is 
 in `README.md`. `type` (`MarkerGroupType`: `POI`, `LINE`, `SHAPE`, or `EXTRUDE`) picks which kind of marker the
 group's signs produce; `lineWidth`/`lineColor` apply to `LINE`/`SHAPE`/`EXTRUDE` groups (setting them on a `POI`
 group is a warning, not an error), and `fillColor` additionally applies to `SHAPE`/`EXTRUDE` (a volume gets a
-floor/ceiling anchored to its members' Y range, per `BlueMapAPIConnector.resolveExtrudeHeightRange`).
+floor/ceiling anchored to its members' Y range, per `MarkerMutations.resolveExtrudeHeightRange`).
 `sorting`/`toggleable` are thin BlueMap `MarkerSet` passthroughs (menu order, hideability) that apply to every group
 type; `depthTest` (terrain occlusion) is `LINE`/`SHAPE`/`EXTRUDE`-only and `cssClasses` (custom.css hooks) is
 `POI`-only, each resolved in `ConfigProvider` and wired into the corresponding BlueMap builder call in
-`BlueMapAPIConnector`.
+`MarkerMutations`.
 `ConfigManager` lazily loads a singleton `BMSMConfigV2`
 via `ConfigProvider` from `config/bluemapsignmarkers/BMSM-Core.json`, creating sane defaults (a single `[poi]` group)
 if the file is missing or fails to load. `SignLinesParser` matches sign text against groups using either
@@ -198,10 +201,13 @@ the persistence loaders/converters (including `Version1SignEntryLoader`, `Versio
 `DispatchedMarkerIdentifier`/`MultiPointMarkerIdentifier`/`LinePoint`, `RenderMaskEvaluator`) — these can be unit tested
 directly (see
 `src/test/java/.../core/signs/SignLinesParserTest.java` for the pattern).
-Code that must reference game types (`SignHelper`, the mixins, `BlueMapSignMarkersMod`, `BlueMapAPIConnector`)
-should stay thin glue around the testable core, since it can only be verified manually via `runServer`.
+Code that must reference game types (`SignHelper`, the mixins, `BlueMapSignMarkersMod`, `BlueMapAPIConnector`,
+`MarkerMutations`) should stay thin glue around the testable core, since it can only be verified manually via
+`runServer`. `MarkerMutations` (the marker-construction logic extracted out of `BlueMapAPIConnector`, see above) is
+mostly game-coupled too, but its `resolveExtrudeHeightRange` static takes/returns no `bluemap-api` types, so it's
+directly testable the same way `BlueMapAPIConnector`'s own `pointOf`/`isInsideRenderBounds` statics are.
 
-`BlueMapAPIConnector` escapes sign text (`HtmlUtils.toHtmlDetail`, in `common`) before it reaches BlueMap's POI
+`MarkerMutations` escapes sign text (`HtmlUtils.toHtmlDetail`, in `common`) before it reaches BlueMap's POI
 marker `detail` field — BlueMap renders `detail` as raw HTML (unlike `label`, which BlueMap escapes itself), and
 sign text is player-controlled, so this closes a live XSS vector. See `agent-context/plans/html-detail-escaping-plan.md` for the
 design. Persisted sign data stays raw/unescaped; escaping happens only at this BlueMap API call site.

--- a/agent-context/README.md
+++ b/agent-context/README.md
@@ -33,4 +33,4 @@ method-level behavior, data-shape history — so an agent doesn't have to re-der
 | `context/testing.md` | `src/test/java/`, `.github/workflows/build.yml`, `.github/workflows/publish.yml` |
 
 ---
-*Last updated: 2026-09-11 | Verified against: feature/tpwalke2/209-actionfactory (5eb0f1d)*
+*Last updated: 2026-09-12 | Verified against: feature/tpwalke2/209-bluemapapiconnector (40f2273)*

--- a/agent-context/context/core-pipeline.md
+++ b/agent-context/context/core-pipeline.md
@@ -490,14 +490,14 @@ Two id schemes now exist side by side (position-keyed and content-keyed), unifie
 - `logProcessingMessage` sanitizes sign-derived detail text via `LogUtils.sanitizeForLog` (`common`, ticket 06)
   before logging it at INFO — strips ANSI CSI escape sequences and normalizes `\r\n`/`\n`/`\r` to literal `\n`
   and `\r`, closing a log-injection/log-noise vector where only `\n` was previously escaped.
-- `processMarkerAction` is `synchronized` (finding #5, resolved 2026-07-22): `addMarker`/`updateMarker`/
-  `removeMarker`/`setLineMarker` mutate a `MarkerSet`'s marker `Map` (thread-safety of which is BlueMap's concern,
-  not this mod's), and `ReactiveQueue`'s executor is sized to `availableProcessors()`, so without this lock two
-  actions dispatched close together (e.g. many signs loading at server startup) could race on the same underlying
-  map. Because `ReactiveQueue.shutdown()` only stops *new* submissions (already-submitted tasks still run — see
-  §7), several such tasks can end up queued behind this monitor for a while after a shutdown is requested;
-  `processMarkerAction` re-checks `BlueMapAPI.getInstance().isEmpty()` itself on entry so one of those queued tasks
-  can't mutate a `MarkerSet` after BlueMap has actually disabled in the meantime. If the dispatched action is a
+- `processMarkerAction` is `synchronized` (finding #5, resolved 2026-07-22): the `MarkerMutations` effects it invokes
+  mutate a `MarkerSet`'s marker `Map` (thread-safety of which is BlueMap's concern, not this mod's), and
+  `ReactiveQueue`'s executor is sized to `availableProcessors()`, so without this lock two actions dispatched close
+  together (e.g. many signs loading at server startup) could race on the same underlying map. Because
+  `ReactiveQueue.shutdown()` only stops *new* submissions (already-submitted tasks still run — see §7), several such
+  tasks can end up queued behind this monitor for a while after a shutdown is requested; `processMarkerAction`
+  re-checks `BlueMapAPI.getInstance().isEmpty()` itself on entry so one of those queued tasks can't mutate a
+  `MarkerSet` after BlueMap has actually disabled in the meantime. If the dispatched action is a
   `GroupTransitionMarkerAction`, it iterates `transitionAction.effects()` (a `List<MarkerAction>`, 0-2 entries —
   see §3/§5) calling `applySingleAction` on each **inside** the same synchronized call, so a bundled leave+join
   pair (or POI↔LINE swap) can never be observed half-applied by another thread; otherwise it calls
@@ -509,71 +509,75 @@ Two id schemes now exist side by side (position-keyed and content-keyed), unifie
   `AGENTS.md`'s "Adding a new marker/BlueMap action" section. All cases resolve their marker sets via a shared
   `prepareGated`/`prepareUngated` helper (parameter type `DispatchedMarkerIdentifier`, needs only `.parentSet()` —
   looks up via `getMarkerSets`, returns a no-op `Runnable` with a debug log if none found, otherwise hands the
-  effect a `Map<String, Marker>` per target map). `RemoveMultiPointMarkerAction` (one class covering line/shape/extrude
-  removal, distinguished by `MultiPointMarkerIdentifier`'s `kind` field — see "Adding a new marker/BlueMap action" in
-  `AGENTS.md`) routes through an id-based `removeMarkerById(String id, Map<String, Marker>)` helper extracted out of the old
-  `removeMarker` body. `SetMultiPointMarkerAction` has one `case` arm covering all three kinds — its own
-  `setMultiPointMarker(SetMultiPointMarkerAction, Map<String, Marker>)` reads `MultiPointMarkerIdentifier.kind()` off
-  the action's identifier and `switch`es (`"line"`/`"shape"`/`"extrude"`, `default` logs a warning) to
-  `setLineMarker`/`setShapeMarker`/`setExtrudeMarker` — this is the one place in `BlueMapAPIConnector` that still
-  needs to tell the three kinds apart, since `ActionFactory` (§5) now dispatches all of them through the single
-  `SetMultiPointMarkerAction`/`RemoveMultiPointMarkerAction` types.
-- `setLineMarker(SetMultiPointMarkerAction, Map<String, Marker>)` builds/replaces a BlueMap `LineMarker`: bails
-  (defensively — `SignManager` should never dispatch below `LINE_MIN_MEMBERS` points, logging a warning if it does)
-  if `action.getPoints().size() < MultiPointGroupThresholds.LINE_MIN_MEMBERS`, otherwise
-  builds a `de.bluecolored.bluemap.api.math.Line` from the action's `LinePoint`s (via `Vector3d`), parses
-  `action.getLineColor()` through `ColorUtils.parseHex` (`common`, plain Java) into `de.bluecolored.bluemap.api.math.Color`,
-  and `put`s a `LineMarker.builder().label(...).detail(HtmlUtils.toHtmlDetail(...)).line(line).lineWidth(...).lineColor(...)
-  .depthTestEnabled(markerGroup.depthTest()).build()` into each marker set's map, keyed by
-  `action.getMarkerIdentifier().getId()` (the content-keyed `"line:" + label` id, §5). `ColorUtils.parseHex` is the
-  only conversion point from the persisted hex string to a real color object, mirroring how `HtmlUtils` is the only
-  conversion point for HTML-escaped `detail` — both convert at the BlueMap-API call site, keeping the rest of the
-  pipeline in plain-Java, unescaped/unconverted form.
-- `setShapeMarker(SetMultiPointMarkerAction, Map<String, Marker>)` is the `SHAPE` counterpart: bails
-  (defensively, mirroring `setLineMarker`) if `action.getPoints().size() < MultiPointGroupThresholds.SHAPE_MIN_MEMBERS`,
-  builds a 2D `Shape` footprint from
-  the points' `x`/`z` only, and takes the marker's rendered height from the **tallest member**:
-  `points.stream().mapToInt(LinePoint::y).max()`. Parses both `lineColor` and `fillColor` through `ColorUtils.parseHex`
-  (fill defaults to a translucent red, `#FF000033`, unlike `lineColor`'s opaque default — see
-  `config-and-persistence.md`), then `put`s a `ShapeMarker.builder().label(...).detail(...).shape(shape,
-  height).lineWidth(...).lineColor(...).fillColor(...).depthTestEnabled(markerGroup.depthTest()).build()` into each
-  marker set's map, keyed by `action.getMarkerIdentifier().getId()` (the content-keyed `"shape:" + label` id, §5).
-- `setExtrudeMarker(SetMultiPointMarkerAction, Map<String, Marker>)` is the `EXTRUDE` counterpart: bails (defensively,
-  mirroring `setShapeMarker`) if `action.getPoints().size() < MultiPointGroupThresholds.EXTRUDE_MIN_MEMBERS`, builds the same 2D `Shape` footprint from the
-  points' `x`/`z` as `setShapeMarker`, but instead of a single tallest-member height calls package-private
-  `resolveExtrudeHeightRange(label, points)` for the volume's floor/ceiling: `minY`/`maxY` are the lowest/tallest
-  member's Y independently (not both from the tallest member), so the extrusion spans the full height range its
-  members were placed at regardless of placement order; if every member is at the same Y (`maxY <= minY`, e.g. one
-  flat floor), it logs at debug and bumps `maxY` to `minY + 1` rather than building a zero-height (invisible)
-  volume. `resolveExtrudeHeightRange` returns a private `ExtrudeHeightRange(float minY, float maxY)` record — a
-  plain value holder with no `bluemap-api` types, so it stays directly unit-testable
-  (`BlueMapAPIConnectorTest`, `testing.md`) even though `BlueMapAPIConnector` itself is otherwise game-coupled and
-  excluded from coverage. Parses both `lineColor` and `fillColor` through `ColorUtils.parseHex` the same way
-  `setShapeMarker` does, then `put`s an `ExtrudeMarker.builder().label(...).detail(...).shape(shape, minY,
-  maxY).lineWidth(...).lineColor(...).fillColor(...).depthTestEnabled(markerGroup.depthTest()).build()` into each
-  marker set's map, keyed by `action.getMarkerIdentifier().getId()` (the content-keyed `"extrude:" + label` id, §5).
-- Two more small helpers are package-private (not `private`) specifically for direct unit testing, alongside
-  `resolveExtrudeHeightRange` above: `pointOf(MarkerIdentifier)` (builds the single-point `List<LinePoint>` used by
-  the render-bounds gate, §8, for a position-keyed POI marker) and `isInsideRenderBounds(RenderMaskEvaluator.RenderMask,
+  effect a `Map<String, Marker>` per target map) — but each `case` arm's actual mutation is now a method reference
+  into `MarkerMutations` (below), not code inlined in `BlueMapAPIConnector` itself (ticket 04,
+  `.scratch/marker-action-consolidation/issues/04-shrink-bluemapapiconnector-marker-mutations.md`).
+- **`MarkerMutations`** (new class in `core.bluemap`, package-private, all-`static`) holds every state-free
+  marker-construction method `BlueMapAPIConnector` used to implement inline — no reference to the connector's
+  queue/cache/lifecycle fields, so this logic can be read (and tested where possible) independent of dispatch/
+  gating/cache concerns. `BlueMapAPIConnector.prepareSingleAction` calls into it via lambdas
+  (`markers -> MarkerMutations.addMarker(addAction, markers)`, etc.) for every `MarkerAction` case.
+  `addMarker`/`updateMarker`/`removeMarker`/`removeMarkerById`/`setMultiPointMarker`/`toBlueMapColor`/
+  `resolveExtrudeHeightRange` all live here now; `pointOf` and `isInsideRenderBounds` (render-bounds gating, §8)
+  stayed on `BlueMapAPIConnector` since they're part of the gating logic, not marker construction, and were
+  explicitly out of scope for ticket 04.
+- `MarkerMutations.setMultiPointMarker(SetMultiPointMarkerAction, Map<String, Marker>)` replaces the former separate
+  `setLineMarker`/`setShapeMarker`/`setExtrudeMarker` methods (ticket 04) with one entry point covering all three
+  kinds: it reads `MultiPointMarkerIdentifier.kind()` off the action's identifier, resolves that kind's minimum
+  member count via a private `minMembersFor(kind)` switch (`MultiPointGroupThresholds.LINE_MIN_MEMBERS`/
+  `SHAPE_MIN_MEMBERS`/`EXTRUDE_MIN_MEMBERS`, warning-and-return if unknown or below threshold — the same defensive
+  guard the three separate methods used to have individually), then parses `action.getLineColor()` once via
+  `toBlueMapColor(ColorUtils.parseHex(...))` before branching into a `switch (kind)` **statement** (not an
+  expression) with one arm per kind:
+  - `"line"` builds a `de.bluecolored.bluemap.api.math.Line` from the action's `LinePoint`s (via `Vector3d`), then
+    `put`s a `LineMarker.builder().label(...).detail(HtmlUtils.toHtmlDetail(...)).line(line).lineWidth(...)
+    .lineColor(...).depthTestEnabled(markerGroup.depthTest()).build()`, keyed by
+    `action.getMarkerIdentifier().getId()` (the content-keyed `"line:" + label` id, §5).
+  - `"shape"` builds a 2D `Shape` footprint from the points' `x`/`z` only, taking the marker's rendered height from
+    the **tallest member** (`points.stream().mapToInt(LinePoint::y).max()`), additionally parses `fillColor`
+    (defaults to a translucent red, `#FF000033`, unlike `lineColor`'s opaque default — see
+    `config-and-persistence.md`), and `put`s a `ShapeMarker.builder()...build()` keyed by the content-keyed
+    `"shape:" + label` id.
+  - `"extrude"` builds the same 2D `Shape` footprint as `"shape"`, but instead of a single tallest-member height
+    calls `resolveExtrudeHeightRange(label, points)` for the volume's floor/ceiling — `minY`/`maxY` are the
+    lowest/tallest member's Y independently (not both from the tallest member), so the extrusion spans the full
+    height range its members were placed at regardless of placement order; if every member is at the same Y
+    (`maxY <= minY`, e.g. one flat floor), it logs at debug and bumps `maxY` to `minY + 1` rather than building a
+    zero-height (invisible) volume. Also parses `fillColor` the same way `"shape"` does, and `put`s an
+    `ExtrudeMarker.builder()...build()` keyed by the content-keyed `"extrude:" + label` id.
+
+  Each arm builds, sets `minDistance`/`maxDistance`, and `put`s its own concretely-typed marker
+  (`LineMarker`/`ShapeMarker`/`ExtrudeMarker`) independently, rather than converging all three into one shared
+  variable typed as their common supertype (`ObjectMarker`) after the switch — `bluemap-api` is `compileOnly` and
+  absent from the test runtime classpath, and a switch **expression** assigning `LineMarker`/`ShapeMarker`/
+  `ExtrudeMarker` branches into one `ObjectMarker`-typed variable forces the JVM verifier to resolve `ObjectMarker`
+  the moment `MarkerMutations` is first loaded — which broke `MarkerMutationsTest`'s coverage of the *unrelated*
+  `resolveExtrudeHeightRange` method purely by being in the same class. The switch **statement** form avoids that
+  merge entirely. `resolveExtrudeHeightRange` returns a private `ExtrudeHeightRange(float minY, float maxY)` record —
+  a plain value holder with no `bluemap-api` types, so it stays directly unit-testable (`MarkerMutationsTest`,
+  `testing.md`) even though the rest of `MarkerMutations` is game-coupled.
+- Two more small helpers stayed on `BlueMapAPIConnector` itself, package-private (not `private`) specifically for
+  direct unit testing: `pointOf(MarkerIdentifier)` (builds the single-point `List<LinePoint>` used by the
+  render-bounds gate, §8, for a position-keyed POI marker) and `isInsideRenderBounds(RenderMaskEvaluator.RenderMask,
   List<LinePoint>)` (the pure mask-vs-points predicate, split out of the `mapId`-taking overload that does the cache
   lookup) — both covered in `BlueMapAPIConnectorTest` without needing a live connector instance or `bluemap-api`
   (`compileOnly`) on the test classpath.
-- `addMarker` only actually builds a marker `if (markerGroup.type() == MarkerGroupType.POI)` — this is a real,
-  live branch now that `MarkerGroupType.LINE`/`SHAPE`/`EXTRUDE` exist (no longer future-proofing for values that
-  didn't exist): a `LINE`-, `SHAPE`-, or `EXTRUDE`-typed group's signs never reach `addMarker` at all, since
-  `SignManager`'s transition table (§3) routes those representations to their own `Set`/`Remove` actions instead of
-  `AddMarkerAction`. It also
-  conditionally calls `markerBuilder.styleClasses(markerGroup.cssClasses().toArray(new String[0]))` when
-  `cssClasses` is non-empty — the only marker-builder call gated on the field being present rather than always
-  called with a possibly-default value, since BlueMap's `styleClasses` has no meaningful "unset" default to fall
-  back to.
-- **HTML escaping (fixed)**: `addMarker`/`updateMarker` wrap `detail` with `HtmlUtils.toHtmlDetail(...)` (`common`
-  package) before it reaches `POIMarker.builder().detail(...)` / `poiMarker.setDetail(...)` — BlueMap renders
-  `detail` as raw HTML (unlike `label`, which BlueMap's own `Marker.setLabel()` escapes), and sign text is
-  player-controlled, so this closed a live XSS vector (`../plans/html-detail-escaping-plan.md`). `toHtmlDetail` escapes
-  first, then converts `\n` to `<br>` so multi-line detail renders line breaks correctly — escaping before the `<br>`
-  substitution matters, otherwise the inserted tags would themselves get escaped. `SignEntry`/persisted `signs.json`
-  data stays raw/unescaped; escaping happens only at this BlueMap-API call site.
+- `MarkerMutations.addMarker` only actually builds a marker `if (markerGroup.type() == MarkerGroupType.POI)` — this
+  is a real, live branch now that `MarkerGroupType.LINE`/`SHAPE`/`EXTRUDE` exist (no longer future-proofing for
+  values that didn't exist): a `LINE`-, `SHAPE`-, or `EXTRUDE`-typed group's signs never reach `addMarker` at all,
+  since `SignManager`'s transition table (§3) routes those representations to their own `Set`/`Remove` actions
+  instead of `AddMarkerAction`. It also conditionally calls
+  `markerBuilder.styleClasses(markerGroup.cssClasses().toArray(new String[0]))` when `cssClasses` is non-empty —
+  the only marker-builder call gated on the field being present rather than always called with a possibly-default
+  value, since BlueMap's `styleClasses` has no meaningful "unset" default to fall back to.
+- **HTML escaping (fixed)**: `MarkerMutations.addMarker`/`updateMarker` wrap `detail` with
+  `HtmlUtils.toHtmlDetail(...)` (`common` package) before it reaches `POIMarker.builder().detail(...)` /
+  `poiMarker.setDetail(...)` — BlueMap renders `detail` as raw HTML (unlike `label`, which BlueMap's own
+  `Marker.setLabel()` escapes), and sign text is player-controlled, so this closed a live XSS vector
+  (`../plans/html-detail-escaping-plan.md`). `toHtmlDetail` escapes first, then converts `\n` to `<br>` so
+  multi-line detail renders line breaks correctly — escaping before the `<br>` substitution matters, otherwise the
+  inserted tags would themselves get escaped. `SignEntry`/persisted `signs.json` data stays raw/unescaped; escaping
+  happens only at this BlueMap-API call site.
 
 ## 7. `ReactiveQueue<T>` — generic buffer-while-unavailable primitive
 
@@ -738,5 +742,5 @@ gating" section. This section covers the code-level mechanics.
   themselves are otherwise unchanged — the fix is localized to `prepareGated`.
 
 ---
-*Last updated: 2026-09-11 | Verified against: feature/tpwalke2/209-actionfactory (5eb0f1d)*
+*Last updated: 2026-09-12 | Verified against: feature/tpwalke2/209-bluemapapiconnector (40f2273)*
 

--- a/agent-context/context/testing.md
+++ b/agent-context/context/testing.md
@@ -24,12 +24,16 @@ sign-persistence loaders/converters/writer (`VersionedFileSignEntryLoader`, `Ver
 `ActionFactory`/`MarkerSetIdentifierCollection`. `SignManager` itself stays game-coupled (its constructor builds a
 `BlueMapAPIConnector`), but its `reparseFromRawLines`/`safeReparseFromRawLines` reparse-on-reload logic (§3 of
 `core-pipeline.md`) is extracted as a package-visible static specifically so it's directly testable.
-`BlueMapAPIConnector` itself stays game-coupled overall, but three helpers (§6 of `core-pipeline.md`) are
+`BlueMapAPIConnector` itself stays game-coupled overall, but two helpers (§6 of `core-pipeline.md`) are
 package-private specifically so they're directly testable (`BlueMapAPIConnectorTest`) without pulling `bluemap-api`
 (`compileOnly`) onto the test classpath or constructing a live connector (which calls `BlueMapAPI.getInstance()`):
-`resolveExtrudeHeightRange` (a plain `ExtrudeHeightRange` record, no `bluemap-api` types), `pointOf` (wraps a
-`MarkerIdentifier`'s coordinates into a single-point `List<LinePoint>`), and `isInsideRenderBounds(RenderMask, ...)`
-(the pure mask-vs-points predicate behind the render-bounds gate, §8).
+`pointOf` (wraps a `MarkerIdentifier`'s coordinates into a single-point `List<LinePoint>`), and
+`isInsideRenderBounds(RenderMask, ...)` (the pure mask-vs-points predicate behind the render-bounds gate, §8).
+`MarkerMutations` (ticket 04, `.scratch/marker-action-consolidation/issues/04-shrink-bluemapapiconnector-marker-mutations.md`
+— extracted out of `BlueMapAPIConnector`) is the same story one level down: game-coupled overall (its methods take
+live `bluemap-api` marker types), but `resolveExtrudeHeightRange` is package-private specifically so it stays
+directly testable (`MarkerMutationsTest`) — a plain `ExtrudeHeightRange` record, no `bluemap-api` types in its
+signature.
 
 `Version1SignEntryLoader` used to be a partial exception — its legacy-shorthand (`"nether"`/`"end"`/`"overworld"`)
 dimension normalization branch read `net.minecraft.world.level.Level`'s static constants, requiring a running
@@ -38,8 +42,9 @@ e.g. `"minecraft:the_nether"`) specifically so `Version1SignEntryLoaderTest` cou
 branches directly instead of only via an already-namespaced dimension string.
 
 Excluded — anything that must reference live game types (`SignHelper`, the two mixins, `BlueMapSignMarkersMod`
-including its `ServerChunkEvents.CHUNK_LOAD` reconciliation handler, `BlueMapAPIConnector` (except its
-`resolveExtrudeHeightRange` static, see above), `SignProvider` itself,
+including its `ServerChunkEvents.CHUNK_LOAD` reconciliation handler, `BlueMapAPIConnector` (except its `pointOf`/
+`isInsideRenderBounds` statics, see above), `MarkerMutations` (except its `resolveExtrudeHeightRange` static, see
+above), `SignProvider` itself,
 since loading/saving calls the game-coupled `SignManager` singleton) — these are thin glue and can only be
 verified manually: `./gradlew runServer` + placing/editing/breaking signs in-game (and, for chunk-load
 reconciliation specifically, removing a sign block without going through the mod — e.g. deleting its chunk's
@@ -358,13 +363,16 @@ As of `main` (`b2c5fa0`), `src/test/java/com/tpwalke2/bluemapsignmarkers/`:
   (`subtract: "true"`) parses identically to the bare form (the fix in commit `217c17f`).
 - `core/bluemap/BlueMapAPIConnectorTest.java` — the sole test class for otherwise-game-coupled `BlueMapAPIConnector`,
   exercising only its package-private statics (see `core-pipeline.md` §6, since even constructing a live connector
-  calls `BlueMapAPI.getInstance()`): `resolveExtrudeHeightRange` (ticket 196) — members all at the same Y get a
-  minimum 1-block height instead of collapsing to zero, members at different Ys span their actual
-  lowest-to-tallest height; `pointOfWrapsAMarkerIdentifiersCoordinatesIntoASinglePointList` confirms `pointOf`
-  builds the single-point list a POI marker's render-bounds check uses; `isInsideRenderBounds(RenderMask, ...)` has
-  a dedicated block using a real `RenderMaskEvaluator.load` fixture — a POI point inside/outside the mask, a
-  multi-point line with at least one member inside (in bounds) vs. every member outside (out of bounds), and an
+  calls `BlueMapAPI.getInstance()`): `pointOfWrapsAMarkerIdentifiersCoordinatesIntoASinglePointList` confirms
+  `pointOf` builds the single-point list a POI marker's render-bounds check uses; `isInsideRenderBounds(RenderMask,
+  ...)` has a dedicated block using a real `RenderMaskEvaluator.load` fixture — a POI point inside/outside the mask,
+  a multi-point line with at least one member inside (in bounds) vs. every member outside (out of bounds), and an
   unbounded mask (no `render-mask` configured) allowing any point.
+- `core/bluemap/MarkerMutationsTest.java` (ticket 04, new — split out of `BlueMapAPIConnectorTest` when
+  `resolveExtrudeHeightRange` moved into the new `MarkerMutations` class alongside the rest of
+  `BlueMapAPIConnector`'s marker-construction logic) — `resolveExtrudeHeightRange`: members all at the same Y get a
+  minimum 1-block height instead of collapsing to zero, members at different Ys span their actual
+  lowest-to-tallest height.
 
 ## CI integration
 
@@ -384,5 +392,5 @@ workflow jobs also now declare an explicit `permissions: contents: read` (least-
 the repo's default token permissions), and `publish.yml`'s job runs under a `modrinth-publish` GitHub Environment.
 
 ---
-*Last updated: 2026-09-11 | Verified against: feature/tpwalke2/209-actionfactory (5eb0f1d)*
+*Last updated: 2026-09-12 | Verified against: feature/tpwalke2/209-bluemapapiconnector (40f2273)*
 

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnector.java
@@ -1,9 +1,6 @@
 package com.tpwalke2.bluemapsignmarkers.core.bluemap;
 
-import com.flowpowered.math.vector.Vector3d;
 import com.tpwalke2.bluemapsignmarkers.Constants;
-import com.tpwalke2.bluemapsignmarkers.common.ColorUtils;
-import com.tpwalke2.bluemapsignmarkers.common.HtmlUtils;
 import com.tpwalke2.bluemapsignmarkers.common.LogUtils;
 import com.tpwalke2.bluemapsignmarkers.config.ConfigManager;
 import com.tpwalke2.bluemapsignmarkers.core.bounds.RenderMaskEvaluator;
@@ -16,24 +13,14 @@ import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.SetMultiPointMarkerA
 import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.UpdateMarkerAction;
 import com.tpwalke2.bluemapsignmarkers.core.markers.DispatchedMarkerIdentifier;
 import com.tpwalke2.bluemapsignmarkers.core.markers.LinePoint;
-import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupType;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerIdentifier;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerSetIdentifier;
-import com.tpwalke2.bluemapsignmarkers.core.markers.MultiPointGroupThresholds;
 import com.tpwalke2.bluemapsignmarkers.core.markers.MultiPointMarkerIdentifier;
 import com.tpwalke2.bluemapsignmarkers.core.reactive.ReactiveQueue;
-import com.flowpowered.math.vector.Vector2d;
 import de.bluecolored.bluemap.api.BlueMapAPI;
 import de.bluecolored.bluemap.api.BlueMapMap;
-import de.bluecolored.bluemap.api.markers.ExtrudeMarker;
-import de.bluecolored.bluemap.api.markers.LineMarker;
 import de.bluecolored.bluemap.api.markers.Marker;
 import de.bluecolored.bluemap.api.markers.MarkerSet;
-import de.bluecolored.bluemap.api.markers.POIMarker;
-import de.bluecolored.bluemap.api.markers.ShapeMarker;
-import de.bluecolored.bluemap.api.math.Color;
-import de.bluecolored.bluemap.api.math.Line;
-import de.bluecolored.bluemap.api.math.Shape;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,7 +130,7 @@ public class BlueMapAPIConnector {
     // (including render-mask gating decisions, which can do cold-cache disk I/O via getRenderMask) up
     // front, and the resulting Runnable is only then run inside a `synchronized (this)` block covering
     // the action's full mutation fan-out (across every one of its target maps). That keeps
-    // addMarker/updateMarker/removeMarker's mutation of a MarkerSet's marker Map from running
+    // MarkerMutations' add/update/remove effects mutating a MarkerSet's marker Map from running
     // concurrently with another dispatched action against the same (or a different) MarkerSet, and one
     // action's effect from ever being observably applied on some of its target maps but not others
     // (findings #5 and the bulk-load fanout item, plans/codebase-review-2026-07-11.md), while ensuring
@@ -195,17 +182,17 @@ public class BlueMapAPIConnector {
     private Runnable prepareSingleAction(MarkerAction markerAction) {
         return switch (markerAction) {
             case AddMarkerAction addAction ->
-                    prepareGated(addAction.getMarkerIdentifier(), pointOf(addAction.getMarkerIdentifier()), markers -> addMarker(addAction, markers));
+                    prepareGated(addAction.getMarkerIdentifier(), pointOf(addAction.getMarkerIdentifier()), markers -> MarkerMutations.addMarker(addAction, markers));
             case UpdateMarkerAction updateAction ->
-                    prepareGated(updateAction.getMarkerIdentifier(), pointOf(updateAction.getMarkerIdentifier()), markers -> updateMarker(updateAction, markers));
+                    prepareGated(updateAction.getMarkerIdentifier(), pointOf(updateAction.getMarkerIdentifier()), markers -> MarkerMutations.updateMarker(updateAction, markers));
             case SetMultiPointMarkerAction setAction ->
-                    prepareGated(setAction.getMarkerIdentifier(), setAction.getPoints(), markers -> setMultiPointMarker(setAction, markers));
+                    prepareGated(setAction.getMarkerIdentifier(), setAction.getPoints(), markers -> MarkerMutations.setMultiPointMarker(setAction, markers));
             // Explicit removes - the sign's representation is genuinely leaving, independent of
             // render bounds - so these apply unconditionally on every real map, no gating needed.
             case RemoveMarkerAction removeAction ->
-                    prepareUngated(removeAction.getMarkerIdentifier(), markers -> removeMarker(removeAction, markers));
+                    prepareUngated(removeAction.getMarkerIdentifier(), markers -> MarkerMutations.removeMarker(removeAction, markers));
             case RemoveMultiPointMarkerAction removeAction ->
-                    prepareUngated(removeAction.getMarkerIdentifier(), markers -> removeMarkerById(removeAction.getMarkerIdentifier().getId(), markers));
+                    prepareUngated(removeAction.getMarkerIdentifier(), markers -> MarkerMutations.removeMarkerById(removeAction.getMarkerIdentifier().getId(), markers));
             default -> {
                 LOGGER.warn("Unknown marker action: {}", markerAction);
                 yield () -> {};
@@ -317,188 +304,6 @@ public class BlueMapAPIConnector {
                 identifier.parentSet().mapId(),
                 position,
                 detail);
-    }
-
-    private static void updateMarker(UpdateMarkerAction updateAction, Map<String, Marker> markers) {
-        LOGGER.debug("Updating marker...");
-
-        var marker = Optional.ofNullable(markers.get(updateAction.getMarkerIdentifier().getId()));
-        if (marker.isEmpty()) return;
-        marker.get().setLabel(updateAction.getNewLabel());
-        if (marker.get() instanceof POIMarker poiMarker) {
-            poiMarker.setDetail(HtmlUtils.toHtmlDetail(updateAction.getNewDetails()));
-        }
-    }
-
-    private static void removeMarker(RemoveMarkerAction removeAction, Map<String, Marker> markers) {
-        LOGGER.debug("Removing marker...");
-        removeMarkerById(removeAction.getMarkerIdentifier().getId(), markers);
-    }
-
-    private static void removeMarkerById(String id, Map<String, Marker> markers) {
-        markers.remove(id);
-    }
-
-    // ColorUtils.parseHex returns alpha in the same 0-255 range as r/g/b, but BlueMap's Color(int, int, int,
-    // float) constructor takes alpha in 0-1 - passing the raw 0-255 int straight through (as the earlier
-    // Color(int, int, int, int alpha-as-int) overload does, treating alpha/255f) is NOT what an int
-    // widening to float gives you: it silently widens to e.g. 51.0f instead of dividing by 255, which
-    // BlueMap then clamps to fully opaque. Every translucent color (e.g. SHAPE's fillColor default) rendered
-    // fully opaque as a result.
-    private static Color toBlueMapColor(int[] rgba) {
-        return new Color(rgba[0], rgba[1], rgba[2], rgba[3] / 255f);
-    }
-
-    // Dispatches to the right BlueMap marker builder for this SetMultiPointMarkerAction's kind (set by
-    // ActionFactory.createSetMultiPointAction on the MultiPointMarkerIdentifier) - a single action type
-    // now covers all three, so this is the one place that still needs to tell them apart.
-    private static void setMultiPointMarker(SetMultiPointMarkerAction action, Map<String, Marker> markers) {
-        var kind = ((MultiPointMarkerIdentifier) action.getMarkerIdentifier()).kind();
-        switch (kind) {
-            case "line" -> setLineMarker(action, markers);
-            case "shape" -> setShapeMarker(action, markers);
-            case "extrude" -> setExtrudeMarker(action, markers);
-            default -> LOGGER.warn("Unknown multi-point marker kind '{}' for label='{}'",
-                    kind, LogUtils.sanitizeForLog(action.getLabel()));
-        }
-    }
-
-    private static void setLineMarker(SetMultiPointMarkerAction action, Map<String, Marker> markers) {
-        LOGGER.debug("Setting line marker...");
-        if (action.getPoints().size() < MultiPointGroupThresholds.LINE_MIN_MEMBERS) {
-            // defensive - SignManager should never dispatch below the minimum; warn so a regression is visible.
-            LOGGER.warn("Refusing to set line marker '{}' with fewer than {} points ({})",
-                    LogUtils.sanitizeForLog(action.getLabel()), MultiPointGroupThresholds.LINE_MIN_MEMBERS, action.getPoints().size());
-            return;
-        }
-
-        var line = new Line(action.getPoints().stream().map(p -> new Vector3d(p.x(), p.y(), p.z())).toList());
-        var color = ColorUtils.parseHex(action.getLineColor());
-        var markerGroup = action.getMarkerIdentifier().parentSet().markerGroup();
-
-        var marker = LineMarker.builder()
-                .label(action.getLabel())
-                .detail(HtmlUtils.toHtmlDetail(action.getDetail()))
-                .line(line)
-                .lineWidth(action.getLineWidth())
-                .lineColor(toBlueMapColor(color))
-                .depthTestEnabled(markerGroup.depthTest())
-                .build();
-        marker.setMinDistance(markerGroup.minDistance());
-        marker.setMaxDistance(markerGroup.maxDistance());
-        markers.put(action.getMarkerIdentifier().getId(), marker);
-    }
-
-    private static void setShapeMarker(SetMultiPointMarkerAction action, Map<String, Marker> markers) {
-        LOGGER.debug("Setting shape marker...");
-        if (action.getPoints().size() < MultiPointGroupThresholds.SHAPE_MIN_MEMBERS) {
-            // defensive - SignManager should never dispatch below the minimum; warn so a regression is visible.
-            LOGGER.warn("Refusing to set shape marker '{}' with fewer than {} points ({})",
-                    LogUtils.sanitizeForLog(action.getLabel()), MultiPointGroupThresholds.SHAPE_MIN_MEMBERS, action.getPoints().size());
-            return;
-        }
-
-        var points = action.getPoints();
-        var shape = new Shape(points.stream().map(p -> new Vector2d(p.x(), p.z())).toList());
-        // Shape height anchors to the tallest member rather than placement order, so the polygon always
-        // clears the terrain/builds of every sign that defines it.
-        var shapeY = (float) points.stream().mapToInt(LinePoint::y).max().orElseThrow();
-        var lineColor = ColorUtils.parseHex(action.getLineColor());
-        var fillColor = ColorUtils.parseHex(action.getFillColor());
-        var markerGroup = action.getMarkerIdentifier().parentSet().markerGroup();
-
-        var marker = ShapeMarker.builder()
-                .label(action.getLabel())
-                .detail(HtmlUtils.toHtmlDetail(action.getDetail()))
-                .shape(shape, shapeY)
-                .lineWidth(action.getLineWidth())
-                .lineColor(toBlueMapColor(lineColor))
-                .fillColor(toBlueMapColor(fillColor))
-                .depthTestEnabled(markerGroup.depthTest())
-                .build();
-        marker.setMinDistance(markerGroup.minDistance());
-        marker.setMaxDistance(markerGroup.maxDistance());
-        markers.put(action.getMarkerIdentifier().getId(), marker);
-    }
-
-    // Floor/ceiling of an extrude volume - a plain value holder (no bluemap-api types), so
-    // resolveExtrudeHeightRange stays testable even though bluemap-api is compileOnly and not on the test
-    // classpath (see AGENTS.md's testable-vs-game-coupled split).
-    record ExtrudeHeightRange(float minY, float maxY) {}
-
-    // Floor/ceiling anchor to the lowest/tallest member respectively, so the volume always spans the full
-    // height range its members were placed at, independent of placement order. All members at the same Y
-    // (e.g. one floor) would otherwise collapse the extrusion to zero height, rendering nothing on the map
-    // with no indication why - so give it a one-block floor instead.
-    static ExtrudeHeightRange resolveExtrudeHeightRange(String label, List<LinePoint> points) {
-        var minY = (float) points.stream().mapToInt(LinePoint::y).min().orElseThrow();
-        var maxY = (float) points.stream().mapToInt(LinePoint::y).max().orElseThrow();
-        if (maxY <= minY) {
-            LOGGER.debug("Extrude marker label='{}' has all members at Y={}; giving it a minimum 1-block height",
-                    LogUtils.sanitizeForLog(label), minY);
-            maxY = minY + 1;
-        }
-        return new ExtrudeHeightRange(minY, maxY);
-    }
-
-    private static void setExtrudeMarker(SetMultiPointMarkerAction action, Map<String, Marker> markers) {
-        LOGGER.debug("Setting extrude marker...");
-        if (action.getPoints().size() < MultiPointGroupThresholds.EXTRUDE_MIN_MEMBERS) {
-            // defensive - SignManager should never dispatch below the minimum; warn so a regression is visible.
-            LOGGER.warn("Refusing to set extrude marker '{}' with fewer than {} points ({})",
-                    LogUtils.sanitizeForLog(action.getLabel()), MultiPointGroupThresholds.EXTRUDE_MIN_MEMBERS, action.getPoints().size());
-            return;
-        }
-
-        var points = action.getPoints();
-        var shape = new Shape(points.stream().map(p -> new Vector2d(p.x(), p.z())).toList());
-        var heightRange = resolveExtrudeHeightRange(action.getLabel(), points);
-        var lineColor = ColorUtils.parseHex(action.getLineColor());
-        var fillColor = ColorUtils.parseHex(action.getFillColor());
-        var markerGroup = action.getMarkerIdentifier().parentSet().markerGroup();
-
-        var marker = ExtrudeMarker.builder()
-                .label(action.getLabel())
-                .detail(HtmlUtils.toHtmlDetail(action.getDetail()))
-                .shape(shape, heightRange.minY(), heightRange.maxY())
-                .lineWidth(action.getLineWidth())
-                .lineColor(toBlueMapColor(lineColor))
-                .fillColor(toBlueMapColor(fillColor))
-                .depthTestEnabled(markerGroup.depthTest())
-                .build();
-        marker.setMinDistance(markerGroup.minDistance());
-        marker.setMaxDistance(markerGroup.maxDistance());
-        markers.put(action.getMarkerIdentifier().getId(), marker);
-    }
-
-    private static void addMarker(AddMarkerAction addAction, Map<String, Marker> markers) {
-        var identifier = addAction.getMarkerIdentifier();
-        var markerGroup = identifier.parentSet().markerGroup();
-        if (markerGroup.type() != MarkerGroupType.POI) {
-            LOGGER.warn("Refusing to add a POI marker for non-POI marker group '{}' (type {})",
-                    markerGroup.name(), markerGroup.type());
-            return;
-        }
-
-        LOGGER.debug("Adding POI marker...");
-        var markerBuilder = POIMarker.builder()
-                .position((double) identifier.x(), (double) identifier.y(), (double) identifier.z())
-                .label(addAction.getLabel())
-                .detail(HtmlUtils.toHtmlDetail(addAction.getDetail()));
-
-        if (markerGroup.icon() != null && !markerGroup.icon().isEmpty()) {
-            markerBuilder.icon(markerGroup.icon(), markerGroup.offsetX(), markerGroup.offsetY());
-        }
-
-        if (!markerGroup.cssClasses().isEmpty()) {
-            markerBuilder.styleClasses(markerGroup.cssClasses().toArray(new String[0]));
-        }
-
-        LOGGER.debug("Adding marker (id {}) to marker set", identifier.getId());
-        var marker = markerBuilder.build();
-        marker.setMinDistance(markerGroup.minDistance());
-        marker.setMaxDistance(markerGroup.maxDistance());
-        markers.put(identifier.getId(), marker);
     }
 
     private void onError(Throwable throwable) {

--- a/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/MarkerMutations.java
+++ b/src/main/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/MarkerMutations.java
@@ -1,0 +1,222 @@
+package com.tpwalke2.bluemapsignmarkers.core.bluemap;
+
+import com.flowpowered.math.vector.Vector2d;
+import com.flowpowered.math.vector.Vector3d;
+import com.tpwalke2.bluemapsignmarkers.Constants;
+import com.tpwalke2.bluemapsignmarkers.common.ColorUtils;
+import com.tpwalke2.bluemapsignmarkers.common.HtmlUtils;
+import com.tpwalke2.bluemapsignmarkers.common.LogUtils;
+import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.AddMarkerAction;
+import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.RemoveMarkerAction;
+import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.SetMultiPointMarkerAction;
+import com.tpwalke2.bluemapsignmarkers.core.bluemap.actions.UpdateMarkerAction;
+import com.tpwalke2.bluemapsignmarkers.core.markers.LinePoint;
+import com.tpwalke2.bluemapsignmarkers.core.markers.MarkerGroupType;
+import com.tpwalke2.bluemapsignmarkers.core.markers.MultiPointGroupThresholds;
+import com.tpwalke2.bluemapsignmarkers.core.markers.MultiPointMarkerIdentifier;
+import de.bluecolored.bluemap.api.markers.ExtrudeMarker;
+import de.bluecolored.bluemap.api.markers.LineMarker;
+import de.bluecolored.bluemap.api.markers.Marker;
+import de.bluecolored.bluemap.api.markers.POIMarker;
+import de.bluecolored.bluemap.api.markers.ShapeMarker;
+import de.bluecolored.bluemap.api.math.Color;
+import de.bluecolored.bluemap.api.math.Line;
+import de.bluecolored.bluemap.api.math.Shape;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+// State-free marker-construction logic pulled out of BlueMapAPIConnector (ticket 04,
+// .scratch/marker-action-consolidation/issues/04-shrink-bluemapapiconnector-marker-mutations.md) - every
+// method here takes only the action being applied and the target MarkerSet's mutable marker Map, with no
+// reference to BlueMapAPIConnector's queue/cache/lifecycle state, so mutation logic can be read (and
+// changed) independent of dispatch/gating/cache concerns.
+final class MarkerMutations {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Constants.MOD_ID);
+
+    private MarkerMutations() {
+    }
+
+    static void addMarker(AddMarkerAction addAction, Map<String, Marker> markers) {
+        var identifier = addAction.getMarkerIdentifier();
+        var markerGroup = identifier.parentSet().markerGroup();
+        if (markerGroup.type() != MarkerGroupType.POI) {
+            LOGGER.warn("Refusing to add a POI marker for non-POI marker group '{}' (type {})",
+                    markerGroup.name(), markerGroup.type());
+            return;
+        }
+
+        LOGGER.debug("Adding POI marker...");
+        var markerBuilder = POIMarker.builder()
+                .position((double) identifier.x(), (double) identifier.y(), (double) identifier.z())
+                .label(addAction.getLabel())
+                .detail(HtmlUtils.toHtmlDetail(addAction.getDetail()));
+
+        if (markerGroup.icon() != null && !markerGroup.icon().isEmpty()) {
+            markerBuilder.icon(markerGroup.icon(), markerGroup.offsetX(), markerGroup.offsetY());
+        }
+
+        if (!markerGroup.cssClasses().isEmpty()) {
+            markerBuilder.styleClasses(markerGroup.cssClasses().toArray(new String[0]));
+        }
+
+        LOGGER.debug("Adding marker (id {}) to marker set", identifier.getId());
+        var marker = markerBuilder.build();
+        marker.setMinDistance(markerGroup.minDistance());
+        marker.setMaxDistance(markerGroup.maxDistance());
+        markers.put(identifier.getId(), marker);
+    }
+
+    static void updateMarker(UpdateMarkerAction updateAction, Map<String, Marker> markers) {
+        LOGGER.debug("Updating marker...");
+
+        var marker = Optional.ofNullable(markers.get(updateAction.getMarkerIdentifier().getId()));
+        if (marker.isEmpty()) return;
+        marker.get().setLabel(updateAction.getNewLabel());
+        if (marker.get() instanceof POIMarker poiMarker) {
+            poiMarker.setDetail(HtmlUtils.toHtmlDetail(updateAction.getNewDetails()));
+        }
+    }
+
+    static void removeMarker(RemoveMarkerAction removeAction, Map<String, Marker> markers) {
+        LOGGER.debug("Removing marker...");
+        removeMarkerById(removeAction.getMarkerIdentifier().getId(), markers);
+    }
+
+    static void removeMarkerById(String id, Map<String, Marker> markers) {
+        markers.remove(id);
+    }
+
+    // Dispatches to the right BlueMap marker builder for this SetMultiPointMarkerAction's kind (set by
+    // ActionFactory.createSetMultiPointAction on the MultiPointMarkerIdentifier) - a single action type
+    // covers line/shape/extrude, so this is the one place that still needs to tell them apart. The shared
+    // preamble (min-member gating, color parsing, min/max distance, storing the built marker) lives once
+    // here; only the actual per-kind BlueMap builder call differs, since LineMarker.Builder/
+    // ShapeMarker.Builder/ExtrudeMarker.Builder share no common builder supertype in bluemap-api.
+    static void setMultiPointMarker(SetMultiPointMarkerAction action, Map<String, Marker> markers) {
+        var identifier = (MultiPointMarkerIdentifier) action.getMarkerIdentifier();
+        var kind = identifier.kind();
+        var points = action.getPoints();
+        var minMembers = minMembersFor(kind);
+        if (minMembers < 0) {
+            LOGGER.warn("Unknown multi-point marker kind '{}' for label='{}'",
+                    kind, LogUtils.sanitizeForLog(action.getLabel()));
+            return;
+        }
+
+        if (points.size() < minMembers) {
+            // defensive - SignManager should never dispatch below the minimum; warn so a regression is visible.
+            LOGGER.warn("Refusing to set {} marker '{}' with fewer than {} points ({})",
+                    kind, LogUtils.sanitizeForLog(action.getLabel()), minMembers, points.size());
+            return;
+        }
+
+        LOGGER.debug("Setting {} marker...", kind);
+        var lineColor = toBlueMapColor(ColorUtils.parseHex(action.getLineColor()));
+        var markerGroup = identifier.parentSet().markerGroup();
+
+        // Each arm builds and stores its own concrete marker type rather than converging on a shared
+        // ObjectMarker-typed variable - bluemap-api is compileOnly (absent from the test runtime
+        // classpath), and a shared variable fed by LineMarker/ShapeMarker/ExtrudeMarker across these
+        // branches forces the verifier to resolve their common supertype (ObjectMarker) the moment this
+        // class is first touched, breaking MarkerMutationsTest's resolveExtrudeHeightRange coverage even
+        // though that method never itself references a bluemap-api type.
+        switch (kind) {
+            case "line" -> {
+                var marker = LineMarker.builder()
+                        .label(action.getLabel())
+                        .detail(HtmlUtils.toHtmlDetail(action.getDetail()))
+                        .line(new Line(points.stream().map(p -> new Vector3d(p.x(), p.y(), p.z())).toList()))
+                        .lineWidth(action.getLineWidth())
+                        .lineColor(lineColor)
+                        .depthTestEnabled(markerGroup.depthTest())
+                        .build();
+                marker.setMinDistance(markerGroup.minDistance());
+                marker.setMaxDistance(markerGroup.maxDistance());
+                markers.put(identifier.getId(), marker);
+            }
+            case "shape" -> {
+                var marker = ShapeMarker.builder()
+                        .label(action.getLabel())
+                        .detail(HtmlUtils.toHtmlDetail(action.getDetail()))
+                        // Shape height anchors to the tallest member rather than placement order, so the
+                        // polygon always clears the terrain/builds of every sign that defines it.
+                        .shape(shapeOf(points), maxY(points))
+                        .lineWidth(action.getLineWidth())
+                        .lineColor(lineColor)
+                        .fillColor(toBlueMapColor(ColorUtils.parseHex(action.getFillColor())))
+                        .depthTestEnabled(markerGroup.depthTest())
+                        .build();
+                marker.setMinDistance(markerGroup.minDistance());
+                marker.setMaxDistance(markerGroup.maxDistance());
+                markers.put(identifier.getId(), marker);
+            }
+            case "extrude" -> {
+                var heightRange = resolveExtrudeHeightRange(action.getLabel(), points);
+                var marker = ExtrudeMarker.builder()
+                        .label(action.getLabel())
+                        .detail(HtmlUtils.toHtmlDetail(action.getDetail()))
+                        .shape(shapeOf(points), heightRange.minY(), heightRange.maxY())
+                        .lineWidth(action.getLineWidth())
+                        .lineColor(lineColor)
+                        .fillColor(toBlueMapColor(ColorUtils.parseHex(action.getFillColor())))
+                        .depthTestEnabled(markerGroup.depthTest())
+                        .build();
+                marker.setMinDistance(markerGroup.minDistance());
+                marker.setMaxDistance(markerGroup.maxDistance());
+                markers.put(identifier.getId(), marker);
+            }
+            default -> throw new IllegalStateException("Unreachable: unknown kind '" + kind + "' already handled above");
+        }
+    }
+
+    private static int minMembersFor(String kind) {
+        return switch (kind) {
+            case "line" -> MultiPointGroupThresholds.LINE_MIN_MEMBERS;
+            case "shape" -> MultiPointGroupThresholds.SHAPE_MIN_MEMBERS;
+            case "extrude" -> MultiPointGroupThresholds.EXTRUDE_MIN_MEMBERS;
+            default -> -1;
+        };
+    }
+
+    private static Shape shapeOf(List<LinePoint> points) {
+        return new Shape(points.stream().map(p -> new Vector2d(p.x(), p.z())).toList());
+    }
+
+    private static float maxY(List<LinePoint> points) {
+        return (float) points.stream().mapToInt(LinePoint::y).max().orElseThrow();
+    }
+
+    // ColorUtils.parseHex returns alpha in the same 0-255 range as r/g/b, but BlueMap's Color(int, int, int,
+    // float) constructor takes alpha in 0-1 - passing the raw 0-255 int straight through (as the earlier
+    // Color(int, int, int, int alpha-as-int) overload does, treating alpha/255f) is NOT what an int
+    // widening to float gives you: it silently widens to e.g. 51.0f instead of dividing by 255, which
+    // BlueMap then clamps to fully opaque. Every translucent color (e.g. SHAPE's fillColor default) rendered
+    // fully opaque as a result.
+    static Color toBlueMapColor(int[] rgba) {
+        return new Color(rgba[0], rgba[1], rgba[2], rgba[3] / 255f);
+    }
+
+    // Floor/ceiling of an extrude volume - a plain value holder (no bluemap-api types), so
+    // resolveExtrudeHeightRange stays testable even though bluemap-api is compileOnly and not on the test
+    // classpath (see AGENTS.md's testable-vs-game-coupled split).
+    record ExtrudeHeightRange(float minY, float maxY) {}
+
+    // Floor/ceiling anchor to the lowest/tallest member respectively, so the volume always spans the full
+    // height range its members were placed at, independent of placement order. All members at the same Y
+    // (e.g. one floor) would otherwise collapse the extrusion to zero height, rendering nothing on the map
+    // with no indication why - so give it a one-block floor instead.
+    static ExtrudeHeightRange resolveExtrudeHeightRange(String label, List<LinePoint> points) {
+        var minY = (float) points.stream().mapToInt(LinePoint::y).min().orElseThrow();
+        var maxY = (float) points.stream().mapToInt(LinePoint::y).max().orElseThrow();
+        if (maxY <= minY) {
+            LOGGER.debug("Extrude marker label='{}' has all members at Y={}; giving it a minimum 1-block height",
+                    LogUtils.sanitizeForLog(label), minY);
+            maxY = minY + 1;
+        }
+        return new ExtrudeHeightRange(minY, maxY);
+    }
+}

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnectorTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/BlueMapAPIConnectorTest.java
@@ -17,31 +17,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-// resolveExtrudeHeightRange, pointOf, and isInsideRenderBounds(RenderMask, ...) are package-private
-// specifically so they're testable without pulling in bluemap-api (compileOnly, not on the test
-// classpath - see the class's other private/game-coupled methods, which can't be exercised this way
-// since even constructing a BlueMapAPIConnector calls BlueMapAPI.getInstance()).
+// pointOf and isInsideRenderBounds(RenderMask, ...) are package-private specifically so they're testable
+// without pulling in bluemap-api (compileOnly, not on the test classpath - see the class's other
+// private/game-coupled methods, which can't be exercised this way since even constructing a
+// BlueMapAPIConnector calls BlueMapAPI.getInstance()). resolveExtrudeHeightRange moved to
+// MarkerMutationsTest alongside the rest of the marker-construction logic it lives with now.
 class BlueMapAPIConnectorTest {
-
-    @Test
-    void allMembersAtTheSameYGetAMinimumOneBlockHeightInsteadOfCollapsingToZero() {
-        var points = List.of(new LinePoint(0, 64, 0), new LinePoint(10, 64, 0), new LinePoint(10, 64, 10));
-
-        var range = BlueMapAPIConnector.resolveExtrudeHeightRange("Town Hall", points);
-
-        assertEquals(64f, range.minY());
-        assertEquals(65f, range.maxY());
-    }
-
-    @Test
-    void membersAtDifferentYsSpanTheirActualLowestToTallestHeight() {
-        var points = List.of(new LinePoint(0, 60, 0), new LinePoint(10, 70, 0), new LinePoint(10, 65, 10));
-
-        var range = BlueMapAPIConnector.resolveExtrudeHeightRange("Town Hall", points);
-
-        assertEquals(60f, range.minY());
-        assertEquals(70f, range.maxY());
-    }
 
     @Test
     void pointOfWrapsAMarkerIdentifiersCoordinatesIntoASinglePointList() {

--- a/src/test/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/MarkerMutationsTest.java
+++ b/src/test/java/com/tpwalke2/bluemapsignmarkers/core/bluemap/MarkerMutationsTest.java
@@ -1,0 +1,34 @@
+package com.tpwalke2.bluemapsignmarkers.core.bluemap;
+
+import com.tpwalke2.bluemapsignmarkers.core.markers.LinePoint;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// resolveExtrudeHeightRange is package-private specifically so it's testable without pulling in
+// bluemap-api (compileOnly, not on the test classpath) - see MarkerMutations' other static
+// marker-construction methods, which can't be exercised this way since they take live bluemap-api types.
+class MarkerMutationsTest {
+
+    @Test
+    void allMembersAtTheSameYGetAMinimumOneBlockHeightInsteadOfCollapsingToZero() {
+        var points = List.of(new LinePoint(0, 64, 0), new LinePoint(10, 64, 0), new LinePoint(10, 64, 10));
+
+        var range = MarkerMutations.resolveExtrudeHeightRange("Town Hall", points);
+
+        assertEquals(64f, range.minY());
+        assertEquals(65f, range.maxY());
+    }
+
+    @Test
+    void membersAtDifferentYsSpanTheirActualLowestToTallestHeight() {
+        var points = List.of(new LinePoint(0, 60, 0), new LinePoint(10, 70, 0), new LinePoint(10, 65, 10));
+
+        var range = MarkerMutations.resolveExtrudeHeightRange("Town Hall", points);
+
+        assertEquals(60f, range.minY());
+        assertEquals(70f, range.maxY());
+    }
+}


### PR DESCRIPTION
## What
Splits `BlueMapAPIConnector`'s marker-construction logic out into a new, state-free `MarkerMutations` class, and merges the three near-identical `setLineMarker`/`setShapeMarker`/`setExtrudeMarker` methods into one.

## Why
`BlueMapAPIConnector` mixed BlueMap listener lifecycle, action-dispatch orchestration, render-bounds gating, MarkerSet cache management, and per-marker-type mutation logic all in one 606-line file — the largest in the repo. Ticket 04 addresses the marker-mutation piece, building on tickets 02/03's consolidation of `Set*MarkerAction` into a single `SetMultiPointMarkerAction`.

## Changes
- New `MarkerMutations` class (`core/bluemap`) holds all static, state-free marker-construction logic: `addMarker`, `updateMarker`, `removeMarker`/`removeMarkerById`, `setMultiPointMarker`, `toBlueMapColor`, `resolveExtrudeHeightRange`/`ExtrudeHeightRange` — no reference to `BlueMapAPIConnector`'s queue/cache/lifecycle state.
- `setLineMarker`/`setShapeMarker`/`setExtrudeMarker` collapsed into one `setMultiPointMarker` method with a shared preamble (min-member gating, color parsing, min/max distance); each kind still builds its own concrete marker type in its own switch branch rather than converging on a shared variable — `LineMarker`/`ShapeMarker`/`ExtrudeMarker` share no common builder supertype in bluemap-api, and converging on one would force the JVM verifier to resolve `ObjectMarker` (a `compileOnly` bluemap-api type absent from the test runtime classpath) as soon as the class loads, breaking unrelated tests.
- `BlueMapAPIConnector` now delegates to `MarkerMutations.*` from `prepareSingleAction` instead of implementing marker construction inline; unused imports removed. Lifecycle, dispatch, bounds gating, and cache responsibilities are untouched.
- `resolveExtrudeHeightRange` tests moved from `BlueMapAPIConnectorTest` into new `MarkerMutationsTest`; `pointOf`/`isInsideRenderBounds` tests stay in `BlueMapAPIConnectorTest` since those methods stay put (out of scope for this ticket).
- No behavior change.

## Testing
- `./gradlew test` — full suite passes, including the relocated `MarkerMutationsTest`.
- `./gradlew build` — passes.
- Manually verified via `runServer`: placing, editing, and removing line, shape, and extrude signs still creates/updates/removes the correct BlueMap markers.