### PR TITLE
#210 publish beta builds to modrinth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,11 +14,15 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # needed for versioning
+      # Keep the branch patterns here (main, releases/**) in sync with the `if:` conditions on the
+      # three publish steps below - each encodes the same restriction independently.
       - name: Verify branch is allowed to publish
         if: startsWith(github.ref, 'refs/heads/')
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.ref_name }}" != "main" ] && [[ "${{ github.ref_name }}" != releases/* ]]; then
-            echo "::error::Publishing is only permitted from main or releases/** branches (got '${{ github.ref_name }}')"
+          if [ "$REF_NAME" != "main" ] && [[ "$REF_NAME" != releases/* ]]; then
+            echo "::error::Publishing is only permitted from main or releases/** branches (got '$REF_NAME')"
             exit 1
           fi
       - name: Set up JDK 25
@@ -41,11 +45,13 @@ jobs:
       - name: summarize test results
         if: always()
         uses: ./.github/actions/summarize-test-results
+      # Branch pattern here must stay in sync with the guard step and the two publish steps below.
       - name: Publish alpha to Modrinth
         if: github.ref == 'refs/heads/main'
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
         run: ./gradlew modrinth -PbuildNumber=${{ github.run_number }}
+      # Branch pattern here must stay in sync with the guard step and the other two publish steps.
       - name: Publish beta to Modrinth
         if: startsWith(github.ref, 'refs/heads/releases/')
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # needed for versioning
+      - name: Verify branch is allowed to publish
+        if: startsWith(github.ref, 'refs/heads/')
+        run: |
+          if [ "${{ github.ref_name }}" != "main" ] && [[ "${{ github.ref_name }}" != releases/* ]]; then
+            echo "::error::Publishing is only permitted from main or releases/** branches (got '${{ github.ref_name }}')"
+            exit 1
+          fi
       - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
@@ -35,10 +42,15 @@ jobs:
         if: always()
         uses: ./.github/actions/summarize-test-results
       - name: Publish alpha to Modrinth
-        if: startsWith(github.ref, 'refs/heads/')
+        if: github.ref == 'refs/heads/main'
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
         run: ./gradlew modrinth -PbuildNumber=${{ github.run_number }}
+      - name: Publish beta to Modrinth
+        if: startsWith(github.ref, 'refs/heads/releases/')
+        env:
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+        run: ./gradlew modrinth -PbuildNumber=${{ github.run_number }} -PisBeta
       - name: Publish release to Modrinth
         if: startsWith(github.ref, 'refs/tags/')
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,10 @@ values there, not in `build.gradle`. `mod_version` follows `<minecraft_version>-
 
 CI (`.github/workflows/build.yml`) runs the unit tests and then `./gradlew build` on push/PR to `main` and
 `releases/**`; either failing fails the job. `.github/workflows/publish.yml` is manually dispatched, also runs the
-unit tests first (a failure blocks publishing), then runs `./gradlew modrinth` to publish to Modrinth (alpha from
-branch dispatch, release from a `v*` tag dispatch with `-PisRelease`).
+unit tests first (a failure blocks publishing), then runs `./gradlew modrinth` to publish to Modrinth: `main` branch
+dispatch → alpha, `releases/**` branch dispatch → beta (`-PisBeta`), `v*` tag dispatch → release (`-PisRelease`,
+exempt from the branch restriction below). A guard step run before the unit tests fails the job outright if a
+branch dispatch targets anything other than `main` or `releases/**`.
 
 Both workflows also have a `summarize test results` step right after `run unit tests` (`if: always()`, so it still
 runs when tests fail). It sums the `tests`/`failures`/`errors`/`skipped` attributes out of Gradle's JUnit XML reports

--- a/agent-context/context/architecture.md
+++ b/agent-context/context/architecture.md
@@ -74,10 +74,12 @@ dev source for `runServer`/`runClient`.
   XML results to `$GITHUB_STEP_SUMMARY` via the shared composite action `.github/actions/summarize-test-results/`
   (plain shell `sed`, no third-party reporter action — see `testing.md` for why) → `./gradlew build` → upload
   `build/libs/` as an artifact
-- `.github/workflows/publish.yml` — manual `workflow_dispatch` only: runs tests first (failure blocks publish), then
-  `./gradlew modrinth -PbuildNumber=<run_number>` (alpha, from a branch dispatch) or the same with `-PisRelease`
+- `.github/workflows/publish.yml` — manual `workflow_dispatch` only: a guard step (before tests) fails the job if a
+  branch dispatch targets anything other than `main` or `releases/**` (tag dispatches are exempt); tests then run
+  (failure blocks publish); then `./gradlew modrinth -PbuildNumber=<run_number>` (alpha, from a `main` branch
+  dispatch), the same with `-PisBeta` (beta, from a `releases/**` branch dispatch), or the same with `-PisRelease`
   (release, from a `v*` tag dispatch)
 
 ---
-*Last updated: 2026-09-11 | Verified against: feature/tpwalke2/209-actionfactory (5eb0f1d)*
+*Last updated: 2026-09-12 | Verified against: main (3cba636, plus uncommitted publish.yml/build.gradle beta-publish changes)*
 

--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,9 @@ modrinth {
 		version = version = "${project.mod_version}.${project.findProperty('buildNumber')}"
 		versionType = "release"
 		changelog.set("Releasenotes and Changelog:\\nhttps://github.com/tpwalke2/BlueMapSignMarkers/releases/tag/v${project.mod_version}")
+	} else if (project.hasProperty('isBeta')) {
+		version = "${project.mod_version}.${project.findProperty('buildNumber')}-beta"
+		versionType = "beta"
 	} else {
 		version = "${project.mod_version}.${project.findProperty('buildNumber')}-alpha"
 		versionType = "alpha"


### PR DESCRIPTION
## What
Adds beta publishing to Modrinth for `releases/**` branches and restricts branch-dispatch publishing to `main`/`releases/**` only (closes #210).

## Why
`publish.yml` previously let any branch dispatch publish an alpha build and had no dedicated beta channel. `releases/**` branches (used for release-candidate hardening) should publish as beta, and publishing from arbitrary branches should be blocked.

## Changes
- `.github/workflows/publish.yml`:
  - New fail-fast guard step (before tests) that fails branch dispatches targeting anything other than `main` or `releases/**` (tag dispatches are exempt)
  - New "Publish beta to Modrinth" step for `releases/**` branch dispatches, running `-PisBeta`
  - "Publish alpha to Modrinth" step narrowed from any branch to `main` only
- `build.gradle`: `modrinth {}` block gains an `isBeta` branch — `versionType = "beta"`, version suffixed `-beta` (mirrors the existing `-alpha`/release branches)
- `AGENTS.md` / `agent-context/context/architecture.md`: docs updated to describe the new alpha/beta/release matrix and the branch guard

## Testing
- No unit-testable logic changed (CI workflow + Gradle publish config only) — verified by inspection of the YAML/Gradle diff
- Manual verification once merged: dispatch `publish.yml` against `main` (expect alpha), a `releases/**` branch (expect beta), and an unrelated branch (expect the guard step to fail before tests run)